### PR TITLE
Add plugin alias feature to close #28

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ return require('packer').startup(function()
 
   -- You can specify multiple plugins in a single call
   use {'tjdevries/colorbuddy.vim', {'nvim-treesitter/nvim-treesitter', opt = true}}
+
+  -- You can alias plugin names
+  use {'dracula/vim', as = 'dracula'}
 end)
 ```
 
@@ -188,6 +191,7 @@ use {
   'myusername/example',   -- The plugin location string
   -- The following keys are all optional
   disable = boolean,           -- Mark a plugin as inactive
+  as = string,                 -- Specifies an alias under which to install the plugin
   installer = function,        -- Specifies custom installer. See "custom installers" below.
   updater = function,          -- Specifies custom updater. See "custom installers" below.
   after = string or list,      -- Specifies plugins to load before this plugin.
@@ -204,7 +208,7 @@ use {
   ft = string or list,         -- Specifies filetypes which load this plugin.
   keys = string or list,       -- Specifies maps which load this plugin. See "Keybindings".
   event = string or list,      -- Specifies autocommand events which load this plugin.
-  cond = string or function,   -- Specifies a conditional test to load this plugin
+  cond = string, function, or list of strings/functions,   -- Specifies a conditional test to load this plugin
   setup = string or function,  -- Specifies code to run before this plugin is loaded.
 }
 ```

--- a/doc/packer.txt
+++ b/doc/packer.txt
@@ -94,6 +94,9 @@ Then you can write your plugin specification in Lua, e.g. (in `~/.config/nvim/lu
 
     -- You can specify multiple plugins in a single call
     use {'tjdevries/colorbuddy.vim', {'nvim-treesitter/nvim-treesitter', opt = true}}
+
+    -- You can alias plugin names
+    use {'dracula/vim', as = 'dracula'}
   end)
 
 `packer` provides the following commands after you've run and configured `packer` with `require('packer').startup(...)`: *packer-default-commands* *packer-commands*
@@ -360,6 +363,7 @@ invoked as follows:
     'myusername/example',   -- The plugin location string
     -- The following keys are all optional
     disable = boolean,           -- Mark a plugin as inactive
+    as = string,                 -- Specifies an alias under which to install the plugin
     installer = function,        -- Specifies custom installer. See "custom installers" below.
     updater = function,          -- Specifies custom updater. See "custom installers" below.
     after = string or list,      -- Specifies plugins to load before this plugin.
@@ -376,7 +380,7 @@ invoked as follows:
     ft = string or list,         -- Specifies filetypes which load this plugin.
     keys = string or list,       -- Specifies maps which load this plugin. See "Keybindings".
     event = string or list,      -- Specifies autocommand events which load this plugin.
-    cond = string or function,   -- Specifies a conditional test to load this plugin
+    cond = string, function, or list of strings/functions,   -- Specifies a conditional test to load this plugin
     setup = string or function,  -- Specifies code to run before this plugin is loaded.
   }
 - With a list of plugins specified in either of the above two forms

--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -111,7 +111,8 @@ manage = function(plugin)
     return
   end
 
-  plugin.short_name = name
+  -- Handle aliases
+  plugin.short_name = plugin.as or name
   plugin.name = path
   plugin.path = path
 

--- a/lua/packer/plugin_utils.lua
+++ b/lua/packer/plugin_utils.lua
@@ -72,6 +72,8 @@ plugin_utils.find_missing_plugins = function(plugins, opt_plugins, start_plugins
     opt_plugins, start_plugins = plugin_utils.list_installed_plugins()
   end
 
+  -- NOTE/TODO: In the case of a plugin gaining/losing an alias, this will force a clean and
+  -- reinstall
   local missing_plugins = {}
   for _, plugin_name in ipairs(vim.tbl_keys(plugins)) do
     local plugin = plugins[plugin_name]


### PR DESCRIPTION
Adds the `as` keyword to allow plugins to be installed under aliases. Closes #28 