### PR TITLE
fix: windows related bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ Neovim.
 - Support for `git` tags, branches, revisions, submodules
 - Support for local plugins
 
+## Requirements
+- You need to be running Neovim v0.5.0+; `packer` makes use of extmarks and other newly-added Neovim
+  features.
+- Your version of Neovim must be compiled with LuaJIT support; `packer` relies on this to detect
+  whether you are running Windows or a Unix-like OS (for path separators)
+- If you are on Windows 10, you need developer mode enabled in order to use local plugins (`packer`
+  needs to use `mklink`, which requires admin privileges - credit to @TimUntersberger for this note)
+
 ## Quickstart
 To get started, first clone this repository to somewhere on your `packpath`, e.g.:
 ```shell

--- a/doc/packer.txt
+++ b/doc/packer.txt
@@ -20,8 +20,14 @@ inspired by the `use-package` library from Emacs.
 ==============================================================================
 REQUIREMENTS                                     *packer-intro-requirements*
 
-You need to be running Neovim v0.5.0+; `packer` makes use of extmarks and
-other newly-added Neovim features.
+- You need to be running Neovim v0.5.0+; `packer` makes use of extmarks and
+  other newly-added Neovim features.
+- Your version of Neovim must be compiled with LuaJIT support; `packer` relies
+  on this to detect whether you are running Windows or a Unix-like OS (for path
+  separators)
+- If you are on Windows 10, you need developer mode enabled in order to use
+  local plugins (`packer` needs to use `mklink`, which requires admin privileges
+  - credit to @TimUntersberger for this note)
 
 ==============================================================================
 FEATURES                                         *packer-intro-features*

--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -78,7 +78,7 @@ packer.init = function(user_config)
 
   config.package_root = vim.fn.fnamemodify(config.package_root, ':p')
   local _
-  config.package_root, _ = string.gsub(config.package_root, '/$', '', 1)
+  config.package_root, _ = string.gsub(config.package_root, util.get_separator() .. '$', '', 1)
   config.pack_dir = util.join_paths(config.package_root, config.plugin_package)
   config.opt_dir = util.join_paths(config.pack_dir, 'opt')
   config.start_dir = util.join_paths(config.pack_dir, 'start')
@@ -110,7 +110,8 @@ manage = function(plugin)
   end
 
   local path = vim.fn.expand(plugin[1])
-  local name_segments = vim.split(path, '/')
+  local name_segments = vim.split(path, util.get_separator())
+
   local segment_idx = #name_segments
   local name = name_segments[segment_idx]
   while name == '' and segment_idx > 0 do

--- a/lua/packer/clean.lua
+++ b/lua/packer/clean.lua
@@ -2,6 +2,7 @@ local plugin_utils = require('packer.plugin_utils')
 local a = require('packer.async')
 local display = require('packer.display')
 local log = require('packer.log')
+local util = require('packer.util')
 
 local await = a.wait
 local async = a.sync
@@ -35,7 +36,13 @@ local clean_plugins = function(_, plugins, results)
       for _, path in pairs(dirty_plugins) do table.insert(lines, '  - ' .. path) end
       if await(display.ask_user('Removing the following directories. OK? (y/N)', lines)) then
         results.removals = dirty_plugins
-        return os.execute('rm -rf ' .. table.concat(vim.tbl_values(dirty_plugins), ' '))
+        if util.is_windows then
+          for _, x in ipairs(vim.tbl_values(dirty_plugins)) do
+            os.execute('cmd /C rmdir /S /Q ' .. x)
+          end
+        else
+          os.execute('rm -rf ' .. table.concat(vim.tbl_values(dirty_plugins), ' '))
+        end
       else
         log.warning('Cleaning cancelled!')
       end

--- a/lua/packer/install.lua
+++ b/lua/packer/install.lua
@@ -1,5 +1,4 @@
 local a            = require('packer.async')
-local log          = require('packer.log')
 local util         = require('packer.util')
 local display      = require('packer.display')
 local plugin_utils = require('packer.plugin_utils')

--- a/lua/packer/install.lua
+++ b/lua/packer/install.lua
@@ -1,4 +1,5 @@
 local a            = require('packer.async')
+local log          = require('packer.log')
 local util         = require('packer.util')
 local display      = require('packer.display')
 local plugin_utils = require('packer.plugin_utils')

--- a/lua/packer/plugin_types/local.lua
+++ b/lua/packer/plugin_types/local.lua
@@ -17,7 +17,7 @@ local function setup_local(plugin)
 
   if vim.fn.executable('ln') == 1 then
     task = {'ln', '-sf', from, to}
-  elseif util.is_windows and vim.fn.executable('mklink') then
+  elseif util.is_windows and vim.fn.executable('mklink') == 1 then
     task = {'cmd', '/C', 'mklink', '/d', to, from}
   else
     log.error('No executable symlink command found!')

--- a/lua/packer/plugin_types/local.lua
+++ b/lua/packer/plugin_types/local.lua
@@ -14,10 +14,11 @@ local function setup_local(plugin)
   local from = plugin.path
   local to = plugin.install_path
   local task
-  if vim.fn.executable('ln') then
+
+  if vim.fn.executable('ln') == 1 then
     task = {'ln', '-sf', from, to}
   elseif util.is_windows and vim.fn.executable('mklink') then
-    task = {'mklink', from, to}
+    task = {'cmd', '/C', 'mklink', '/d', to, from}
   else
     log.error('No executable symlink command found!')
     return
@@ -27,6 +28,7 @@ local function setup_local(plugin)
   plugin.installer = function(disp)
     return async(function()
       disp:task_update(plugin_name, 'making symlink...')
+      jobs.run(task, {capture_output = true})
       return await(jobs.run(task, {capture_output = true}))
     end)
   end

--- a/lua/packer/plugin_utils.lua
+++ b/lua/packer/plugin_utils.lua
@@ -19,7 +19,8 @@ plugin_utils.guess_type = function(plugin)
     plugin.url = plugin.path
     plugin.type = 'git'
   else
-    plugin.url = 'https://github.com/' .. plugin.path
+    local path = table.concat(vim.split(plugin.path, "\\", true), "/")
+    plugin.url = 'https://github.com/' .. path
     plugin.type = 'git'
   end
 end

--- a/lua/packer/plugin_utils.lua
+++ b/lua/packer/plugin_utils.lua
@@ -92,7 +92,10 @@ plugin_utils.load_plugin = function(plugin)
     vim.cmd('packadd ' .. plugin.short_name)
   else
     vim.o.runtimepath = vim.o.runtimepath .. ',' .. plugin.install_path
-    for _, pat in ipairs({'plugin/**/*.vim', 'after/plugin/**/*.vim'}) do
+    for _, pat in ipairs({
+      table.concat({'plugin', '**', '*.vim'}, util.get_separator()),
+      table.concat({'after', 'plugin', '**', '*.vim'}, util.get_separator()),
+    }) do
       local path = util.join_paths(plugin.install_path, pat)
       local glob_ok, files = pcall(vim.fn.glob, path, false, true)
       if not glob_ok then

--- a/lua/packer/util.lua
+++ b/lua/packer/util.lua
@@ -32,19 +32,21 @@ util.nonempty_or = function(opt, alt)
 end
 
 util.is_windows = jit.os == 'Windows'
-local function get_separator()
+
+util.get_separator = function()
   if util.is_windows then return '\\' end
   return '/'
 end
 
 util.join_paths = function(...)
-  local separator = get_separator()
+  local separator = util.get_separator()
   return table.concat({...}, separator)
 end
 
 util.get_plugin_full_name = function(plugin)
   local plugin_name = plugin.name
   if plugin.branch and plugin.branch ~= 'master' then
+    -- NOTE: maybe have to change the seperator here too
     plugin_name = plugin_name .. '/' .. plugin.branch
   end
 


### PR DESCRIPTION
Fixed the problems mentioned in #43 .

# Fixes

### Sometimes forgot to call `get_separator`

### in lua numbers are always true

> When used as control expression, the only false values in Lua are false and nil , everything else is evaluated as true value

This means that the following if statement is always true, because `vim.fn.executable` returns a number

```lua
vim.fn.executable('ln')
```

### `mklink` requires admin privileges

In Windows 10 you need to have developer mode enabled to use local plugins. This should probably be mentioned in the README.

I don't know where to put this, so could you please do this?

### `mklink` signature

`mklink` has the `from` and `to` swapped.

### powershell instead of cmd

It looks like your job lib is using powershell and not cmd. This means that you have to use `cmd /C mklink ...` instead of `mklink ...`

### mklink doesn't automatically create directory symlinks

Don't think I need to explain this. You just forgot the `/d` flag of `mklink`.
