### PR TITLE
Use command for current branch compatible with old git versions

### DIFF
--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -41,7 +41,7 @@ local config_defaults = {
       fetch = '-C %s fetch --depth 999999 --progress',
       checkout = '-C %s checkout %s --',
       update_branch = '-C %s merge --ff-only @{u}',
-      current_branch = '-C %s branch --show-current',
+      current_branch = '-C %s rev-parse --abbrev-ref HEAD',
       diff = '-C %s log --color=never --pretty=format:FMT --no-show-signature HEAD@{1}...HEAD',
       diff_fmt = '%%h %%s (%%cr)',
       get_rev = '-C %s rev-parse --short HEAD',


### PR DESCRIPTION
Fixes #52. @gagbo confirms that this changed command works for old `git` versions. However, the output appears to be slightly different on detached HEAD repos, i.e. if we have a specific commit checked out - this version prints `HEAD`, whereas `git branch --show-current` prints nothing.

I need to try to check if that difference will break anything (basically, I need to review the `git` logic and make sure we're not expecting an empty string anywhere); then this can be merged.