### PR TITLE
add lua block in sequence_lines

### DIFF
--- a/lua/packer/compile.lua
+++ b/lua/packer/compile.lua
@@ -380,9 +380,9 @@ local function make_loaders(_, plugins)
     if loaders[plugin].only_sequence and not loaders[plugin].only_setup then
       table.insert(sequence_lines, 'packadd ' .. plugin)
       if plugins[plugin].config then
-        local lines = {'', '-- Config for: ' .. plugin}
+        local lines = {'lua << END', '-- Config for: ' .. plugin}
         vim.list_extend(lines, plugins[plugin].config)
-        table.insert(lines, '')
+        table.insert(lines, 'END')
         vim.list_extend(sequence_lines, lines)
       end
     end


### PR DESCRIPTION
Thank you for your great plugin!

I've created following configuration, and start with `nvim -u minimal_init.vim` then it generate following `packer_load.vim`. It seems miss lua block for `require'plugin.rc.completion-buffers'.config()`, so I've tried to add lua block.
And, I'm newbie to lua, so I'm sorry if my misunderstanding.


#### `minimal_init.vim`

```vim
set packpath=./
set runtimepath=$VIMRUNTIME

packadd packer.nvim

lua << EOF
local packer = require('packer')
local use = packer.use

local config = {
    package_root = './pack'
}

packer.init(config)

use {
    'nvim-lua/completion-nvim',
    setup = "require'plugin.rc.completion-nvim'.setup()",
    config = "require'plugin.rc.completion-nvim'.config()",
}

use {
    'steelsojka/completion-buffers',
    after = {
        "completion-nvim",
    },
    config = "require'plugin.rc.completion-buffers'.config()",
}

packer.compile('./plugin/packer_load.vim')
EOF
```

#### `plugin/packer_load.vim`

```vim
(omit...)

function! s:load(names, cause) abort
call luaeval('_packer_load(_A[1], _A[2])', [a:names, a:cause])
endfunction

" Runtimepath customization

" Load plugins in order defined by `after`
packadd completion-buffers

-- Config for: completion-buffers
require'plugin.rc.completion-buffers'.config()


" Command lazy-loads

" Keymap lazy-loads

(omit...)
```



