### PR TITLE
Added so the buffer shows info when open

### DIFF
--- a/lua/packer/display.lua
+++ b/lua/packer/display.lua
@@ -383,6 +383,7 @@ end
 
 --- Utility to make the initial display buffer header
 local function make_header(disp)
+  api.nvim_buf_set_option(buf, 'modifiable', true)
   local width = api.nvim_win_get_width(0)
   local pad_width = math.floor((width - string.len(config.title)) / 2.0)
   api.nvim_buf_set_lines(disp.buf, 0, 1, true, {
@@ -428,7 +429,6 @@ display.open = function(opener)
   disp.marks = {}
   disp.plugins = {}
   disp.ns = api.nvim_create_namespace('')
-  vim.o.modifiable = true
   make_header(disp)
   setup_window(disp)
 

--- a/lua/packer/display.lua
+++ b/lua/packer/display.lua
@@ -428,7 +428,7 @@ display.open = function(opener)
   disp.marks = {}
   disp.plugins = {}
   disp.ns = api.nvim_create_namespace('')
-  vim.wo.modifiable = true
+  vim.o.modifiable = true
   make_header(disp)
   setup_window(disp)
 

--- a/lua/packer/display.lua
+++ b/lua/packer/display.lua
@@ -428,6 +428,7 @@ display.open = function(opener)
   disp.marks = {}
   disp.plugins = {}
   disp.ns = api.nvim_create_namespace('')
+  vim.wo.modifiable = true
   make_header(disp)
   setup_window(disp)
 


### PR DESCRIPTION
Before when I called PackerSync or PackerUpdate, I would get an error in display.lua line 388; which reads 'Buffer is not "modifiable"'.
![packer_error](https://user-images.githubusercontent.com/52523838/94543277-09def280-0274-11eb-8188-ac6ba535fb31.png)
So to fix it, I added  `api.nvim_buf_set_option(buf, 'modifiable', true)` in `make_header` above the function to get width.
