### PR TITLE
feat(compile): Feature guard around nvim

### DIFF
--- a/lua/packer/compile.lua
+++ b/lua/packer/compile.lua
@@ -7,6 +7,12 @@ local config = nil
 
 local function cfg(_config) config = _config end
 
+local feature_guard = [[
+if !has('nvim')
+  finish
+endif
+]]
+
 local vim_loader = [[
 function! s:load(names, cause) abort
 call luaeval('_packer_load(_A[1], _A[2])', [a:names, a:cause])
@@ -417,7 +423,9 @@ local function make_loaders(_, plugins)
   -- Output everything:
 
   -- First, the Lua code
-  local result = {'" Automatically generated packer.nvim plugin loader code\n', 'lua << END'}
+  local result = {'" Automatically generated packer.nvim plugin loader code\n'}
+  table.insert(result, feature_guard)
+  table.insert(result, 'lua << END')
   table.insert(result, fmt('local plugins = %s\n', vim.inspect(loaders)))
   table.insert(result, lua_loader)
   -- Then the runtimepath line


### PR DESCRIPTION
If user has a shared configuration for nvim and vim this feature guard
will check if the user is on nvim if they are not then it will just
`finish` sourcing the file.

Users might want to have the same configuration for both neovim and vim.
If for some reason they are on vim instead of nvim their configuration
will gracefully degrate intead of throwing errors.

As the compiled file vimscript file is in the users runtime it should
degrade gracefully.

Fix: #65 