### PR TITLE
Readme updates: clarify that v0.4.4 is too old, mention autocmd PackerCompile

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ Neovim.
   https://github.com/neovim/neovim/commit/3853276d9cacc99a2698117e904475dbf7033383), users will need
   to update to a version of Neovim **after** the aforementioned PR was merged. There are currently
   shims around the changed functions which should maintain support for earlier versions of Neovim,
-  but these are intended to be temporary and will be removed by **2020-10-04**.
+  but these are intended to be temporary and will be removed by **2020-10-04**. Therefore
+  Packer will not work with Neovim v0.4.4, which was relased before the `extmark` change.
 
 ## Features
 - Declarative plugin specification
@@ -110,6 +111,12 @@ end)
 -- Performs `PackerClean` and then `PackerUpdate`
 :PackerSync
 ```
+
+You can configure Neovim to automatically run `:PackerCompile` whenever `plugins.lua` is updated with an autocommand:
+```
+autocmd BufWritePost plugins.lua PackerCompile
+```
+This autocommand can be placed in your `init.vim`, or any other startup file as per your setup.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Neovim.
   to update to a version of Neovim **after** the aforementioned PR was merged. There are currently
   shims around the changed functions which should maintain support for earlier versions of Neovim,
   but these are intended to be temporary and will be removed by **2020-10-04**. Therefore
-  Packer will not work with Neovim v0.4.4, which was relased before the `extmark` change.
+  Packer will not work with Neovim v0.4.4, which was released before the `extmark` change.
 
 ## Features
 - Declarative plugin specification


### PR DESCRIPTION
* Clarify that "stable" Neovim v0.4.4 is not supported by Packer
* Demonstrate the use of `autocmd` to run `PackerCompile` whenever the plugin script is updated