### PR TITLE
Fix #100: copy existing environment variable values

### DIFF
--- a/lua/packer/plugin_types/git.lua
+++ b/lua/packer/plugin_types/git.lua
@@ -123,11 +123,13 @@ git.setup = function(plugin)
       stderr = jobs.logging_callback(output.err.stderr, output.data.stderr, nil, disp, plugin_name)
     }
 
+    local job_env = vim.loop.os_environ()
+    job_env['GIT_TERMINAL_PROMPT'] = 0
     local installer_opts = {
       capture_output = callbacks,
       timeout = config.clone_timeout,
       options = {
-        env = {'GIT_TERMINAL_PROMPT=0'},
+        env = job_env,
       },
     }
 

--- a/lua/packer/plugin_types/git.lua
+++ b/lua/packer/plugin_types/git.lua
@@ -124,8 +124,13 @@ git.setup = function(plugin)
     }
 
     if git.job_env == nil then
-      git.job_env = vim.fn.environ()
-      git.job_env['GIT_TERMINAL_PROMPT'] = 0
+      local job_env = {}
+      for k, v in pairs(vim.fn.environ()) do
+        if k ~= 'GIT_TERMINAL_PROMPT' then table.insert(job_env, k .. '=' .. v) end
+      end
+
+      table.insert(job_env, 'GIT_TERMINAL_PROMPT=0')
+      git.job_env = job_env
     end
 
     local installer_opts = {


### PR DESCRIPTION
Copy the entire environment before assigning `GIT_TERMINAL_PROMPT`