### PR TITLE
display: add a non_interactive config parameter

### DIFF
--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -53,6 +53,7 @@ local config_defaults = {
     clone_timeout = 60
   },
   display = {
+    non_interactive = false,
     open_fn = nil,
     open_cmd = '65vnew [packer]',
     working_sym = '⟳',


### PR DESCRIPTION
Following up on #106: the idea is to be able to run PackerSync and have
it cleanup stale plugins without asking for input (imagine the user is
in --headless mode).

Originally, I had a no_input parameter, but based on feedback I updated
the code to have a config parameter that modifies the behavior of the
display module.
