### PR TITLE
Test for Neovim 0.5 on packer_compiled

### DIFF
--- a/lua/packer/compile.lua
+++ b/lua/packer/compile.lua
@@ -8,7 +8,7 @@ local config = nil
 local function cfg(_config) config = _config end
 
 local feature_guard = [[
-if !has('nvim')
+if !has('nvim-0.5')
   finish
 endif
 ]]

--- a/lua/packer/compile.lua
+++ b/lua/packer/compile.lua
@@ -9,6 +9,9 @@ local function cfg(_config) config = _config end
 
 local feature_guard = [[
 if !has('nvim-0.5')
+  echohl WarningMsg
+  echom "Invalid Neovim version for packer.nvim!"
+  echohl None
   finish
 endif
 ]]


### PR DESCRIPTION
When using older versions of Neovim alongside `packer`, `has('nvim')` isn't quite restrictive enough. We need to know for sure if we have 0.5.