### PR TITLE
Document display window keybindings

### DIFF
--- a/doc/packer.txt
+++ b/doc/packer.txt
@@ -337,6 +337,14 @@ where `plugins` is the global table of managed plugins, `plugin` is the table
 for a specific plugin, and `value` is the value associated with key `name` in
 `plugin`.
 
+RESULTS WINDOW KEYBINDINGS                     *packer-results-keybindings*
+Once an operation completes, the results are shown in the display window.
+`packer` sets up default keybindings for this window:
+
+q                    close the display window
+<CR>                 toggle information about a particular plugin
+r                    revert an update
+
 ==============================================================================
 API                                            *packer-api*
 

--- a/lua/packer/display.lua
+++ b/lua/packer/display.lua
@@ -232,6 +232,17 @@ local display_mt = {
 
     if #raw_lines == 0 then table.insert(raw_lines, ' Everything already up to date!') end
 
+    local keymap_definitions = {
+      { lhs = keymaps[1][2], action = 'quit' },
+      { lhs = keymaps[2][2], action = 'show more info' },
+      { lhs = keymaps[3][2], action = 'revert an update' },
+    }
+    table.insert(raw_lines, '')
+    for _, keymap in ipairs(keymap_definitions) do
+      table.insert(raw_lines,
+                   string.format(" Press '%s' to %s", keymap.lhs, keymap.action))
+    end
+
     -- Ensure there are no newlines
     local lines = {}
     for _, line in ipairs(raw_lines) do


### PR DESCRIPTION
This PR implements the changes described in #35.

- `packer` now displays available keybindings in the results window
- these keybindings are documented in `:help`

Let me know if you have any comments about style or if I should make other changes.