### PR TITLE
Make results window keybindings configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,11 @@ default configuration values (and structure of the configuration table) are:
     moved_sym = '→', -- The symbol for a plugin which was moved (e.g. from opt to start)
     header_sym = '━', -- The symbol for the header line in packer's display
     show_all_info = true, -- Should packer show all update details automatically?
+    keybindings = { -- Keybindings for the display window
+      quit = 'q',
+      toggle_info = '<CR>',
+      prompt_revert = 'r',
+    }
   }
 }
 ```

--- a/doc/packer.txt
+++ b/doc/packer.txt
@@ -350,7 +350,9 @@ q                    close the display window
 <CR>                 toggle information about a particular plugin
 r                    revert an update
 
-They can be configured by changing the value of `config.display.keybindings`.
+They can be configured by changing the value of `config.display.keybindings`
+(see |packer-configuration|). Setting it to `false` will disable all keybindings.
+Setting any of its keys to `false` will disable the corresponding keybinding.
 
 ==============================================================================
 API                                            *packer-api*

--- a/doc/packer.txt
+++ b/doc/packer.txt
@@ -220,6 +220,11 @@ default values: >
       moved_sym = '→', -- The symbol for a plugin which was moved (e.g. from opt to start)
       header_sym = '━', -- The symbol for the header line in packer's display
       show_all_info = true, -- Should packer show all update details automatically?
+      keybindings = { -- Keybindings for the display window
+        quit = 'q',
+        toggle_info = '<CR>',
+        prompt_revert = 'r',
+      }
     }
   }
 
@@ -344,6 +349,8 @@ Once an operation completes, the results are shown in the display window.
 q                    close the display window
 <CR>                 toggle information about a particular plugin
 r                    revert an update
+
+They can be configured by changing the value of `config.display.keybindings`.
 
 ==============================================================================
 API                                            *packer-api*

--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -65,6 +65,11 @@ local config_defaults = {
     header_lines = 2,
     title = 'packer.nvim',
     show_all_info = true,
+    keybindings = {
+      quit = 'q',
+      toggle_info = '<CR>',
+      prompt_revert = 'r',
+    }
   }
 }
 

--- a/lua/packer/display.lua
+++ b/lua/packer/display.lua
@@ -441,10 +441,8 @@ end
 --- Initialize options, settings, and keymaps for display windows
 local function setup_window(disp)
   api.nvim_buf_set_option(disp.buf, 'filetype', 'packer')
-  if config.keybindings then
-    for _, m in pairs(keymaps) do
-      if m.lhs then api.nvim_buf_set_keymap(disp.buf, 'n', m.lhs, m.rhs, {nowait = true, silent = true}) end
-    end
+  for _, m in pairs(keymaps) do
+    if m.lhs then api.nvim_buf_set_keymap(disp.buf, 'n', m.lhs, m.rhs, {nowait = true, silent = true}) end
   end
   for _, c in ipairs(config.filetype_cmds) do vim.cmd(c) end
 end

--- a/lua/packer/display.lua
+++ b/lua/packer/display.lua
@@ -248,8 +248,10 @@ local display_mt = {
 
     table.insert(raw_lines, '')
     for _, keymap in ipairs(keymap_display_order) do
-      table.insert(raw_lines,
-                   string.format(" Press '%s' to %s", keymaps[keymap].lhs, keymaps[keymap].action))
+      if keymaps[keymap].lhs then
+        table.insert(raw_lines,
+                     string.format(" Press '%s' to %s", keymaps[keymap].lhs, keymaps[keymap].action))
+      end
     end
 
     -- Ensure there are no newlines
@@ -418,7 +420,11 @@ end
 
 display.cfg = function(_config)
   config = _config.display
-  for name, lhs in pairs(config.keybindings) do keymaps[name].lhs = lhs end
+  if config.keybindings then
+    for name, lhs in pairs(config.keybindings) do
+      if keymaps[name] then keymaps[name].lhs = lhs end
+    end
+  end
   config.filetype_cmds = make_filetype_cmds(config.working_sym, config.done_sym, config.error_sym)
 end
 
@@ -435,7 +441,11 @@ end
 --- Initialize options, settings, and keymaps for display windows
 local function setup_window(disp)
   api.nvim_buf_set_option(disp.buf, 'filetype', 'packer')
-  for _, m in pairs(keymaps) do api.nvim_buf_set_keymap(disp.buf, 'n', m.lhs, m.rhs, {nowait = true, silent = true}) end
+  if config.keybindings then
+    for _, m in pairs(keymaps) do
+      if m.lhs then api.nvim_buf_set_keymap(disp.buf, 'n', m.lhs, m.rhs, {nowait = true, silent = true}) end
+    end
+  end
   for _, c in ipairs(config.filetype_cmds) do vim.cmd(c) end
 end
 


### PR DESCRIPTION
Closes #34

This PR makes the keybindings of the display window configurable via `config.display.keybindings`

A few notes/questions:
- There is no validation process for the keybindings, users can input invalid mappings
- Should there be an option to disable the keybindings altogether?
- I can delete `keymap_display_order` if you think it makes the the code harder to read for no real benefit