### PR TITLE
Fix update error

### DIFF
--- a/lua/packer/display.lua
+++ b/lua/packer/display.lua
@@ -154,6 +154,7 @@ local display_mt = {
   --- Update the status message of a task in progress
   task_update = vim.schedule_wrap(function(self, plugin, message)
     if not self:valid_display() then return end
+    if not self.marks[plugin] then return end
     local line, _ = get_extmark_by_id(self.buf, self.ns, self.marks[plugin])
     self:set_lines(line[1], line[1] + 1,
                    {string.format(' %s %s: %s', config.working_sym, plugin, message)})


### PR DESCRIPTION
Prevents the error:
```
Error executing vim.schedule lua callback: .../site/pack/packer/opt/packer.nvim/lua/packer/display.lua:157: Expected 4 arguments
```

Which is caused when passing `id=nil` into `nvim_buf_get_extmark_by_id`. I think this happens when an update finishes quickly as it causes `self.marks[plugin] = nil` to be called. Not really sure though.

Btw this happens on a plugin repo which I had modified with local commits and pushed to a fork, not sure why that would matter though.