### PR TITLE
Use aliased name as plugin name if present

### DIFF
--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -154,7 +154,7 @@ manage = function(plugin)
   end
 
   -- Handle aliases
-  plugin.short_name = plugin.as or name
+  plugin.short_name = name
   plugin.name = path
   plugin.path = path
 

--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -131,7 +131,7 @@ manage = function(plugin)
   local name_segments = vim.split(path, util.get_separator())
 
   local segment_idx = #name_segments
-  local name = name_segments[segment_idx]
+  local name = plugin.as or name_segments[segment_idx]
   while name == '' and segment_idx > 0 do
     name = name_segments[segment_idx]
     segment_idx = segment_idx - 1


### PR DESCRIPTION
This is in reference to #140. Before, the `as` name was not used preferentially to the repo name provided in the specification. This will make the `as` alias be used instead, if present.

Closes #140