### PR TITLE
Detect plugin.type changes

### DIFF
--- a/lua/packer/compile.lua
+++ b/lua/packer/compile.lua
@@ -1,5 +1,6 @@
 -- Compiling plugin specifications to Lua for lazy-loading
 local util = require('packer.util')
+local plugin_utils = require('packer.plugin_utils')
 local log = require('packer.log')
 local fmt = string.format
 
@@ -19,6 +20,10 @@ local vim_loader = [[
 function! s:load(names, cause) abort
 call luaeval('_packer_load(_A[1], _A[2])', [a:names, a:cause])
 endfunction
+]]
+
+local plugin_accessor = [[
+function PackerGetCompiled(plugin) return plugins[plugin] end
 ]]
 
 local lua_loader = [[
@@ -274,6 +279,8 @@ local function make_loaders(_, plugins)
         plugin.only_config = true
         configs[name] = plugin.executable_config
       end
+
+      loaders[name].type = plugin.type
     end
   end
 
@@ -432,6 +439,7 @@ then
   table.insert(result, feature_guard)
   table.insert(result, 'lua << END')
   table.insert(result, fmt('local plugins = %s\n', vim.inspect(loaders)))
+  table.insert(result, plugin_accessor)
   table.insert(result, lua_loader)
   -- Then the runtimepath line
   table.insert(result, '-- Runtimepath customization')

--- a/lua/packer/plugin_utils.lua
+++ b/lua/packer/plugin_utils.lua
@@ -82,8 +82,13 @@ plugin_utils.find_missing_plugins = function(plugins, opt_plugins, start_plugins
   local missing_plugins = {}
   for _, plugin_name in ipairs(vim.tbl_keys(plugins)) do
     local plugin = plugins[plugin_name]
-    if (not plugin.opt and not start_plugins[util.join_paths(config.start_dir, plugin.short_name)])
-      or (plugin.opt and not opt_plugins[util.join_paths(config.opt_dir, plugin.short_name)]) then
+
+    local plugin_list = plugin.opt and opt_plugins or start_plugins
+    local plugin_path = config[plugin.opt and 'opt_dir' or 'start_dir']
+
+    local plugin_installed = plugin_list[util.join_paths(plugin_path, plugin.short_name)]
+
+    if not plugin_installed or plugin.type ~= PackerGetCompiled(plugin_name).type then
       table.insert(missing_plugins, plugin_name)
     end
   end


### PR DESCRIPTION
This PR adds necessary checks in order to determine whether or not a plugin type has changed during the most recent compile, and will install the plugin accordingly.

Todo:

* [ ] Alter logic of `:PackerClean` so that properly detected missing plugins have a directory to install to.
  * Currently, this PR can make `packer` detect that a plugin's type has changed, but then it will fail to reinstall because the directory will not have been cleaned. That is my next goal.

Topics left to discussion:

* [ ] Better way to get `packer` compiled plugin table than global function?

Closes #118