### PR TITLE
Check dir type for changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,8 +149,8 @@ local fn = vim.fn
 local install_path = fn.stdpath('data')..'/site/pack/packer/opt/packer.nvim'
 
 if fn.empty(fn.glob(install_path)) > 0 then
-	execute('!git clone https://github.com/wbthomason/packer.nvim '..install_path)
-    execute 'packadd packer.nvim'
+  execute('!git clone https://github.com/wbthomason/packer.nvim '..install_path)
+  execute 'packadd packer.nvim'
 end
 ```
 
@@ -382,7 +382,7 @@ to generate the lazy-loader file!
 
 ## Status
 **tl;dr**: Beta. Things seem to work and most features are complete, but certainly not every edge
-case has been tested. People willing to give it a try and report bugs/errors are very welcome! 
+case has been tested. People willing to give it a try and report bugs/errors are very welcome!
 
 - Basic package management works (i.e. installation, updating, cleaning, start/opt plugins,
   displaying results)

--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -178,7 +178,7 @@ manage = function(plugin)
                                         plugin.short_name)
 
   if not plugin.type then plugin_utils.guess_type(plugin) end
-  if plugin.type ~= 'custom' then plugin_types[plugin.type].setup(plugin) end
+  if plugin.type ~= plugin_utils.custom_plugin then plugin_types[plugin.type].setup(plugin) end
   for k, v in pairs(plugin) do if handlers[k] then handlers[k](plugins, plugin, v) end end
   plugins[plugin.short_name] = plugin
 

--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -178,7 +178,7 @@ manage = function(plugin)
                                         plugin.short_name)
 
   if not plugin.type then plugin_utils.guess_type(plugin) end
-  if plugin.type ~= plugin_utils.custom_plugin then plugin_types[plugin.type].setup(plugin) end
+  if plugin.type ~= plugin_utils.custom_plugin_type then plugin_types[plugin.type].setup(plugin) end
   for k, v in pairs(plugin) do if handlers[k] then handlers[k](plugins, plugin, v) end end
   plugins[plugin.short_name] = plugin
 

--- a/lua/packer/clean.lua
+++ b/lua/packer/clean.lua
@@ -49,14 +49,14 @@ local clean_plugins = function(_, plugins, results)
       local plugin_missing = missing_plugins[plugin_config.short_name] and vim.loop.fs_stat(path)
 
       if plugin_missing or is_dirty(plugin_config, plugin_source) then
-        dirty_plugins[#dirty_plugins+1] = path
+        table.insert(dirty_plugins, path)
       end
     end
 
     -- Any path which was not set to `nil` above will be set to dirty here
     local function mark_remaining_as_dirty(plugin_list)
       for path, _ in pairs(plugin_list) do
-        dirty_plugins[#dirty_plugins+1] = path
+        table.insert(dirty_plugins, path)
       end
     end
 

--- a/lua/packer/clean.lua
+++ b/lua/packer/clean.lua
@@ -13,7 +13,7 @@ local PLUGIN_OPTIONAL_LIST = 1
 local PLUGIN_START_LIST = 2
 
 local function is_dirty(plugin, typ)
-  return plugin.disable or (plugin.opt and typ == 2) or (not plugin.opt and typ == 1)
+  return plugin.disable or (plugin.opt and typ == PLUGIN_START_LIST) or (not plugin.opt and typ == PLUGIN_OPTIONAL_LIST)
 end
 
 -- Find and remove any plugins not currently configured for use

--- a/lua/packer/clean.lua
+++ b/lua/packer/clean.lua
@@ -32,7 +32,7 @@ local clean_plugins = function(_, plugins, results)
       missing_plugins[idx] = nil
     end
 
-	 -- test for dirty / 'missing' plugins
+    -- test for dirty / 'missing' plugins
     for _, plugin_config in pairs(plugins) do
       local path = plugin_config.install_path
 
@@ -45,7 +45,7 @@ local clean_plugins = function(_, plugins, results)
         start_plugins[path] = nil
       end
 
-		-- We don't want to report paths which don't exist for removal; that will confuse people
+      -- We don't want to report paths which don't exist for removal; that will confuse people
       local plugin_missing = missing_plugins[plugin_config.short_name] and vim.loop.fs_stat(path)
 
       if plugin_missing or is_dirty(plugin_config, plugin_source) then
@@ -56,7 +56,7 @@ local clean_plugins = function(_, plugins, results)
     -- Any path which was not set to `nil` above will be set to dirty here
     local function mark_remaining_as_dirty(plugin_list)
       for path, _ in pairs(plugin_list) do
-		    dirty_plugins[#dirty_plugins+1] = path
+        dirty_plugins[#dirty_plugins+1] = path
       end
     end
 

--- a/lua/packer/display.lua
+++ b/lua/packer/display.lua
@@ -269,8 +269,8 @@ local display_mt = {
         if plugin.output.err and #plugin.output.err > 0 then
           table.insert(plugin_data.lines, '  Errors:')
           for _, line in ipairs(plugin.output.err) do
-	    line = vim.trim(line)
-	    if line:find('\n') then
+            line = vim.trim(line)
+            if line:find('\n') then
               for sub_line in line:gmatch("[^\r\n]+") do
                 table.insert(plugin_data.lines, '    ' .. sub_line)
               end

--- a/lua/packer/display.lua
+++ b/lua/packer/display.lua
@@ -1,6 +1,7 @@
 local api = vim.api
 local log = require('packer.log')
 local a = require('packer.async')
+local plugin_utils = require('packer.plugin_utils')
 
 local in_headless = #api.nvim_list_uis() == 0
 
@@ -221,7 +222,7 @@ local display_mt = {
         local actual_update = true
         local failed_update = false
         if result.ok then
-          if plugin.type ~= 'git' or plugin.revs[1] == plugin.revs[2] then
+          if plugin.type ~= plugin_utils.git_plugin or plugin.revs[1] == plugin.revs[2] then
             actual_update = false
             table.insert(message, string.format(' %s %s is already up to date', config.done_sym,
                                                 plugin_name))

--- a/lua/packer/display.lua
+++ b/lua/packer/display.lua
@@ -222,7 +222,7 @@ local display_mt = {
         local actual_update = true
         local failed_update = false
         if result.ok then
-          if plugin.type ~= plugin_utils.git_plugin or plugin.revs[1] == plugin.revs[2] then
+          if plugin.type ~= plugin_utils.git_plugin_type or plugin.revs[1] == plugin.revs[2] then
             actual_update = false
             table.insert(message, string.format(' %s %s is already up to date', config.done_sym,
                                                 plugin_name))

--- a/lua/packer/plugin_utils.lua
+++ b/lua/packer/plugin_utils.lua
@@ -8,20 +8,41 @@ local config = nil
 local plugin_utils = {}
 plugin_utils.cfg = function(_config) config = _config end
 
+plugin_utils.custom_plugin = 'custom'
+plugin_utils.local_plugin = 'local'
+plugin_utils.git_plugin = 'git'
+
 plugin_utils.guess_type = function(plugin)
   if plugin.installer then
-    plugin.type = 'custom'
+    plugin.type = plugin_utils.custom_plugin
   elseif vim.fn.isdirectory(plugin.path) ~= 0 then
     plugin.url = plugin.path
-    plugin.type = 'local'
+    plugin.type = plugin_utils.local_plugin
   elseif string.sub(plugin.path, 1, 6) == 'git://' or string.sub(plugin.path, 1, 4) == 'http'
     or string.match(plugin.path, '@') then
     plugin.url = plugin.path
-    plugin.type = 'git'
+    plugin.type = plugin_utils.git_plugin
   else
     local path = table.concat(vim.split(plugin.path, "\\", true), "/")
     plugin.url = 'https://github.com/' .. path
-    plugin.type = 'git'
+    plugin.type = plugin_utils.git_plugin
+  end
+end
+
+plugin_utils.guess_dir_type = function(dir)
+  local globdir = vim.fn.glob(dir)
+  local dir_type = (vim.loop.fs_lstat(globdir) or {type='noexist'}).type
+
+  --[[ NOTE: We're assuming here that:
+             1. users only create custom plugins for non-git repos;
+             2. custom plugins don't use symlinks to install;
+             otherwise, there's no consistent way to tell from a dir alone… ]]
+  if dir_type == 'link' then
+    return plugin_utils.local_plugin
+  elseif vim.loop.fs_stat(globdir..'/.git') then
+    return plugin_utils.git_plugin
+  elseif dir_type ~= 'noexist' then
+    return plugin_utils.custom_plugin
   end
 end
 
@@ -82,8 +103,11 @@ plugin_utils.find_missing_plugins = function(plugins, opt_plugins, start_plugins
   local missing_plugins = {}
   for _, plugin_name in ipairs(vim.tbl_keys(plugins)) do
     local plugin = plugins[plugin_name]
-    if (not plugin.opt and not start_plugins[util.join_paths(config.start_dir, plugin.short_name)])
-      or (plugin.opt and not opt_plugins[util.join_paths(config.opt_dir, plugin.short_name)]) then
+
+    local plugin_path = util.join_paths(config[plugin.opt and 'opt_dir' or 'start_dir'], plugin.short_name)
+    local plugin_installed = (plugin.opt and opt_plugins or start_plugins)[plugin_path]
+
+    if not plugin_installed or plugin.type ~= plugin_utils.guess_dir_type(plugin_path) then
       table.insert(missing_plugins, plugin_name)
     end
   end

--- a/lua/packer/plugin_utils.lua
+++ b/lua/packer/plugin_utils.lua
@@ -8,24 +8,24 @@ local config = nil
 local plugin_utils = {}
 plugin_utils.cfg = function(_config) config = _config end
 
-plugin_utils.custom_plugin = 'custom'
-plugin_utils.local_plugin = 'local'
-plugin_utils.git_plugin = 'git'
+plugin_utils.custom_plugin_type = 'custom'
+plugin_utils.local_plugin_type = 'local'
+plugin_utils.git_plugin_type = 'git'
 
 plugin_utils.guess_type = function(plugin)
   if plugin.installer then
-    plugin.type = plugin_utils.custom_plugin
+    plugin.type = plugin_utils.custom_plugin_type
   elseif vim.fn.isdirectory(plugin.path) ~= 0 then
     plugin.url = plugin.path
-    plugin.type = plugin_utils.local_plugin
+    plugin.type = plugin_utils.local_plugin_type
   elseif string.sub(plugin.path, 1, 6) == 'git://' or string.sub(plugin.path, 1, 4) == 'http'
     or string.match(plugin.path, '@') then
     plugin.url = plugin.path
-    plugin.type = plugin_utils.git_plugin
+    plugin.type = plugin_utils.git_plugin_type
   else
     local path = table.concat(vim.split(plugin.path, "\\", true), "/")
     plugin.url = 'https://github.com/' .. path
-    plugin.type = plugin_utils.git_plugin
+    plugin.type = plugin_utils.git_plugin_type
   end
 end
 
@@ -38,11 +38,11 @@ plugin_utils.guess_dir_type = function(dir)
              2. custom plugins don't use symlinks to install;
              otherwise, there's no consistent way to tell from a dir alone… ]]
   if dir_type == 'link' then
-    return plugin_utils.local_plugin
+    return plugin_utils.local_plugin_type
   elseif vim.loop.fs_stat(globdir..'/.git') then
-    return plugin_utils.git_plugin
+    return plugin_utils.git_plugin_type
   elseif dir_type ~= 'noexist' then
-    return plugin_utils.custom_plugin
+    return plugin_utils.custom_plugin_type
   end
 end
 

--- a/lua/packer/update.lua
+++ b/lua/packer/update.lua
@@ -70,7 +70,7 @@ local function update_plugin(plugin, display_win, results)
     local r = await(plugin.updater(display_win))
     if r ~= nil and r.ok then
       local msg = 'up to date'
-      if plugin.type == 'git' then
+      if plugin.type == plugin_utils.git_plugin then
         local info = r.info
         local actual_update = info.revs[1] ~= info.revs[2]
         msg = actual_update and ('updated: ' .. info.revs[1] .. '...' .. info.revs[2])

--- a/lua/packer/update.lua
+++ b/lua/packer/update.lua
@@ -70,7 +70,7 @@ local function update_plugin(plugin, display_win, results)
     local r = await(plugin.updater(display_win))
     if r ~= nil and r.ok then
       local msg = 'up to date'
-      if plugin.type == plugin_utils.git_plugin then
+      if plugin.type == plugin_utils.git_plugin_type then
         local info = r.info
         local actual_update = info.revs[1] ~= info.revs[2]
         msg = actual_update and ('updated: ' .. info.revs[1] .. '...' .. info.revs[2])


### PR DESCRIPTION
This is a followup to #143. It uses a more consistent method for checking the type of a directory than attempting to embed it into the `packer_compile`.

The following changes have been made:

* `plugin_utils.find_missing_plugins` now uses two metrics to determine whether or not a plugin is "missing":
    1. The plugin is not installed at all (directory is missing).
    2. The plugin is installed, but the `guess_dir_type` does not match `plugin.type`.
* `PackerClean` has been re-implemented in terms of `find_missing_plugins`. This is because some missing plugins are also plugins which need to be cleaned before a reinstall (i.e. moving from local to upstream and vice versa).
    * See the commit message for 51bf0962d450eebe7d123a41279810ee1724406c. Essentially it just uses more logic from other parts of the plugin.
* More strings and numbers have been converted to variables in case the values change in the future.

Closes #118.