### PR TITLE
Fix jump on operator lazy-loading

### DIFF
--- a/lua/packer/compile.lua
+++ b/lua/packer/compile.lua
@@ -115,7 +115,7 @@ _packer_load = function(names, cause)
     end
 
     if cause.prefix then
-      local prefix = vim.v.count and vim.v.count or ''
+      local prefix = vim.v.count ~= 0 and vim.v.count or ''
       prefix = prefix .. '"' .. vim.v.register .. cause.prefix
       if vim.fn.mode('full') == 'no' then
         if vim.v.operator == 'c' then


### PR DESCRIPTION
Fixes #115

Just a small additional check for the value of `vim.v.count`, otherwise it's always truthy