### PR TITLE
Feature/lazy load via undef function

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ A table given to `use` can take two forms:
    and may additionally have a number of optional keyword elements, shown below:
 ```lua
 use {
-  'myusername/example',   -- The plugin location string
+  'myusername/example',        -- The plugin location string
   -- The following keys are all optional
   disable = boolean,           -- Mark a plugin as inactive
   as = string,                 -- Specifies an alias under which to install the plugin
@@ -275,13 +275,14 @@ use {
   commit = string,             -- Specifies a git commit to use
   lock = boolean,              -- Skip this plugin in updates/syncs
   run = string or function,    -- Post-update/install hook. See "update/install hooks".
-  requires = string or list -- Specifies plugin dependencies. See "dependencies".
+  requires = string or list    -- Specifies plugin dependencies. See "dependencies".
   config = string or function, -- Specifies code to run after this plugin is loaded.
   -- The following keys all imply lazy-loading
   cmd = string or list,        -- Specifies commands which load this plugin.
   ft = string or list,         -- Specifies filetypes which load this plugin.
   keys = string or list,       -- Specifies maps which load this plugin. See "Keybindings".
   event = string or list,      -- Specifies autocommand events which load this plugin.
+  func = string or list        -- Specifies functions which load this plugin.
   cond = string, function, or list of strings/functions,   -- Specifies a conditional test to load this plugin
   setup = string or function,  -- Specifies code to run before this plugin is loaded.
 }

--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ use {
   ft = string or list,         -- Specifies filetypes which load this plugin.
   keys = string or list,       -- Specifies maps which load this plugin. See "Keybindings".
   event = string or list,      -- Specifies autocommand events which load this plugin.
-  func = string or list        -- Specifies functions which load this plugin.
+  fn = string or list          -- Specifies functions which load this plugin.
   cond = string, function, or list of strings/functions,   -- Specifies a conditional test to load this plugin
   setup = string or function,  -- Specifies code to run before this plugin is loaded.
 }

--- a/doc/packer.txt
+++ b/doc/packer.txt
@@ -413,7 +413,7 @@ invoked as follows:
 - With a single plugin location string, e.g. `use <STRING>`
 - With a single plugin specification table, e.g. >
   use {
-    'myusername/example',   -- The plugin location string
+    'myusername/example',        -- The plugin location string
     -- The following keys are all optional
     disable = boolean,           -- Mark a plugin as inactive
     as = string,                 -- Specifies an alias under which to install the plugin
@@ -427,13 +427,14 @@ invoked as follows:
     commit = string,             -- Specifies a git commit to use
     lock = boolean,              -- Skip this plugin in updates/syncs
     run = string or function,    -- Post-update/install hook. See |packer-plugin-hooks|
-    requires = string or list -- Specifies plugin dependencies. See |packer-plugin-dependencies|
+    requires = string or list    -- Specifies plugin dependencies. See |packer-plugin-dependencies|
     config = string or function, -- Specifies code to run after this plugin is loaded.
     -- The following keys all imply lazy-loading
     cmd = string or list,        -- Specifies commands which load this plugin.
     ft = string or list,         -- Specifies filetypes which load this plugin.
     keys = string or list,       -- Specifies maps which load this plugin. See |packer-plugin-keybindings|
     event = string or list,      -- Specifies autocommand events which load this plugin.
+    func = string or list        -- Specifies functions which load this plugin.
     cond = string, function, or list of strings/functions,   -- Specifies a conditional test to load this plugin
     setup = string or function,  -- Specifies code to run before this plugin is loaded.
   }

--- a/doc/packer.txt
+++ b/doc/packer.txt
@@ -434,7 +434,7 @@ invoked as follows:
     ft = string or list,         -- Specifies filetypes which load this plugin.
     keys = string or list,       -- Specifies maps which load this plugin. See |packer-plugin-keybindings|
     event = string or list,      -- Specifies autocommand events which load this plugin.
-    func = string or list        -- Specifies functions which load this plugin.
+    fn = string or list          -- Specifies functions which load this plugin.
     cond = string, function, or list of strings/functions,   -- Specifies a conditional test to load this plugin
     setup = string or function,  -- Specifies code to run before this plugin is loaded.
   }

--- a/lua/packer/compile.lua
+++ b/lua/packer/compile.lua
@@ -151,7 +151,7 @@ local function make_loaders(_, plugins)
   local commands = {}
   local keymaps = {}
   local after = {}
-  local funcs = {}
+  local fns = {}
   for name, plugin in pairs(plugins) do
     if not plugin.disable then
       local quote_name = "'" .. name .. "'"
@@ -270,15 +270,15 @@ local function make_loaders(_, plugins)
           end
         end
         
-        if plugin.func then
+        if plugin.fn then
           loaders[name].only_sequence = false
           loaders[name].only_setup = false
 
-          if type(plugin.func) == 'string' then plugin.func = {plugin.func} end
+          if type(plugin.fn) == 'string' then plugin.fn = {plugin.fn} end
 
-          for _, func in ipairs(plugin.func) do
-            funcs[func] = funcs[func] or {}
-            table.insert(funcs[func], quote_name)
+          for _, fn in ipairs(plugin.fn) do
+            fns[fn] = fns[fn] or {}
+            table.insert(fns[fns], quote_name)
           end
         end
       end
@@ -382,9 +382,9 @@ then
     end
   end
 
-  local func_aucmds = {}
-  for func, names in pairs(funcs) do
-    table.insert(func_aucmds, fmt('  au FuncUndefined %s ++once call s:load([%s], {})', func,
+  local fn_aucmds = {}
+  for fn, names in pairs(fns) do
+    table.insert(fn_aucmds, fmt('  au FuncUndefined %s ++once call s:load([%s], {})', fn,
                                 table.concat(names, ', ')))
   end
 
@@ -486,7 +486,7 @@ then
   table.insert(result, '  " Event lazy-loads')
   vim.list_extend(result, event_aucmds)
   table.insert(result, '  " Function lazy-loads')
-  vim.list_extend(result, func_aucmds)
+  vim.list_extend(result, fn_aucmds)
   table.insert(result, 'augroup END\n')
 
   -- And a final package path update


### PR DESCRIPTION
Fixes: #131 

I usually prefer to have full names in code. But since `function` (although not its plural) is a reserved word in Lua, I decided to make an exception and name it `func` (and `funcs` respectively).