### PR TITLE
Fix escaping of keys with <Plug> for lazy loading

### DIFF
--- a/lua/packer/compile.lua
+++ b/lua/packer/compile.lua
@@ -128,9 +128,10 @@ _packer_load = function(names, cause)
       vim.fn.feedkeys(prefix, 'n')
     end
 
-    -- NOTE: I'm not sure if the below substitution is correct; it might correspond to the literal
-    -- characters \<Plug> rather than the special <Plug> key.
-    vim.fn.feedkeys(string.gsub(string.gsub(cause.keys, '^<Plug>', '\\<Plug>') .. extra, '<[cC][rR]>', '\r'))
+    local formatted_plug_key = string.format('%c%c%c', 0x80, 253, 83)
+    local keys = string.gsub(cause.keys, '^<Plug>', formatted_plug_key) .. extra
+    local escaped_keys = string.gsub(keys, '<[cC][rR]>', '\r')
+    vim.fn.feedkeys(escaped_keys)
   elseif cause.event then
     vim.cmd(fmt('doautocmd <nomodeline> %s', cause.event))
   elseif cause.ft then

--- a/lua/packer/compile.lua
+++ b/lua/packer/compile.lua
@@ -343,10 +343,12 @@ then
   for keymap, names in pairs(keymaps) do
     local prefix = nil
     if keymap[1] ~= 'i' then prefix = '' end
-    local cr_escaped_map = string.gsub(keymap[2], '<[cC][rR]>', '\\<CR\\>')
+    local escaped_map = string.gsub(keymap[2], '<[cC][rR]>', '\\<CR\\>')
+    escaped_map = string.gsub(escaped_map, '<Plug>', '\\<Plug\\>')
+
     local keymap_line = fmt(
                           '%snoremap <silent> %s <cmd>call <SID>load([%s], { "keys": "%s"%s })<cr>',
-                          keymap[1], keymap[2], table.concat(names, ', '), cr_escaped_map,
+                          keymap[1], keymap[2], table.concat(names, ', '), escaped_map,
                           prefix == nil and '' or (', "prefix": "' .. prefix .. '"'))
 
     table.insert(keymap_defs, keymap_line)


### PR DESCRIPTION
This is still not working 100%. While the created mapping in the compiled script does not throw an error anymore and successfully loads the packages, the feedkeys do not have an affect. The next time the keys are typed they take effect. I think must be related to [this here](https://github.com/wbthomason/packer.nvim/blob/f62f2fc1fb1802a217afdbac6a487e541019f658/lua/packer/compile.lua#L133). According to [the docs](https://neovim.io/doc/user/eval.html#feedkeys()) this requires to use double quotes to make the special keys working. But I don't know how to achieve that. The [nvim_feedkeys](https://neovim.io/doc/user/api.html#nvim_feedkeys()) API function allows to specify a parameter to "trigger" the auto-espace of special chars. But it still does not work for me. Does someone has an idea?