### PR TITLE
ref: clean before :PackerInstall/Update

### DIFF
--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -246,9 +246,9 @@ packer.install = function(...)
   end
 
   async(function()
-    vim.cmd 'PackerClean'
     local start_time = vim.fn.reltime()
     local results = {}
+    await(clean(plugins, results))
     local tasks, display_win = install(plugins, install_plugins, results)
     if next(tasks) then
       table.insert(tasks, 1, function() return not display.status.running end)
@@ -280,9 +280,9 @@ end
 packer.update = function(...)
   local update_plugins = args_or_all(...)
   async(function()
-    vim.cmd 'PackerClean'
     local start_time = vim.fn.reltime()
     local results = {}
+    await(clean(plugins, results))
     local missing_plugins, installed_plugins = util.partition(
                                                  plugin_utils.find_missing_plugins(plugins),
                                                  update_plugins)

--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -100,8 +100,8 @@ packer.init = function(user_config)
   plugin_utils.ensure_dirs()
 
   if not config.disable_commands then
-    vim.cmd [[command! PackerInstall  lua require('packer').install()]]
-    vim.cmd [[command! PackerUpdate   lua require('packer').update()]]
+    vim.cmd [[command! PackerInstall  lua local packer = require 'packer'; packer.clean(); packer.install()]]
+    vim.cmd [[command! PackerUpdate   lua local packer = require 'packer'; packer.clean(); packer.update()]]
     vim.cmd [[command! PackerSync     lua require('packer').sync()]]
     vim.cmd [[command! PackerClean    lua require('packer').clean()]]
     vim.cmd [[command! PackerCompile  lua require('packer').compile()]]

--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -246,7 +246,7 @@ packer.install = function(...)
   end
 
   async(function()
-    packer.clean()
+    vim.cmd 'PackerClean'
     local start_time = vim.fn.reltime()
     local results = {}
     local tasks, display_win = install(plugins, install_plugins, results)
@@ -280,7 +280,7 @@ end
 packer.update = function(...)
   local update_plugins = args_or_all(...)
   async(function()
-    packer.clean()
+    vim.cmd 'PackerClean'
     local start_time = vim.fn.reltime()
     local results = {}
     local missing_plugins, installed_plugins = util.partition(

--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -100,8 +100,8 @@ packer.init = function(user_config)
   plugin_utils.ensure_dirs()
 
   if not config.disable_commands then
-    vim.cmd [[command! PackerInstall  lua local packer = require 'packer'; packer.clean(); packer.install()]]
-    vim.cmd [[command! PackerUpdate   lua local packer = require 'packer'; packer.clean(); packer.update()]]
+    vim.cmd [[command! PackerInstall  lua require('packer').install()]]
+    vim.cmd [[command! PackerUpdate   lua require('packer').update()]]
     vim.cmd [[command! PackerSync     lua require('packer').sync()]]
     vim.cmd [[command! PackerClean    lua require('packer').clean()]]
     vim.cmd [[command! PackerCompile  lua require('packer').compile()]]
@@ -246,6 +246,7 @@ packer.install = function(...)
   end
 
   async(function()
+    packer.clean()
     local start_time = vim.fn.reltime()
     local results = {}
     local tasks, display_win = install(plugins, install_plugins, results)
@@ -279,6 +280,7 @@ end
 packer.update = function(...)
   local update_plugins = args_or_all(...)
   async(function()
+    packer.clean()
     local start_time = vim.fn.reltime()
     local results = {}
     local missing_plugins, installed_plugins = util.partition(


### PR DESCRIPTION
This is a followup to #144. We discussed that `:PackerInstall` and `:PackerUpdate` needed to clean before peforming their operations, since directory changes may have occurred. In order to prevent an increase to the complexity of `:PackerSync`, this PR implements changes to the high-level Vim commands `:PackerInstall` and `:PackerUpdate` in order to perform the clean.

* This means that `packer.install()` and `packer.update()` do not clean automatically, but their respective commands do.

I'm happy to discuss this solution as well as potential alternatives.