### PR TITLE
Reload required config/setup modules before packer compile

### DIFF
--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -381,7 +381,7 @@ end
 --- return a function, then cross reference them with all
 --- the plugin configs and setups and if there are any matches
 --- reload the user module.
-local function precompile(plugs)
+local function refresh_configs(plugs)
   local reverse_index = {}
   for k, v in pairs(package.loaded) do
     if type(v) == "function" then
@@ -400,7 +400,7 @@ end
 -- Takes an optional argument of a path to which to output the resulting compiled code
 packer.compile = function(output_path)
   output_path = output_path or config.compile_path
-  precompile(plugins)
+  refresh_configs(plugins)
   -- NOTE: we copy the plugins table so the in memory value is not mutated during compilation
   local compiled_loader = compile(vim.deepcopy(plugins))
   output_path = vim.fn.expand(output_path)

--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -369,10 +369,29 @@ packer.sync = function(...)
   end)()
 end
 
+local function precompile(plugs)
+  local reverse_index = {}
+  for k, v in pairs(package.loaded) do
+    if type(v) == "function" then
+        reverse_index[v] = k
+    end
+  end
+  -- TODO also reload setup as well as config
+  for _, plugin in pairs(plugs) do
+    local value = plugin.config
+    local package_name = reverse_index[value]
+    if package_name then
+      package.loaded[package_name] = nil
+      require(package_name)
+    end
+  end
+end
+
 --- Update the compiled lazy-loader code
 -- Takes an optional argument of a path to which to output the resulting compiled code
 packer.compile = function(output_path)
   output_path = output_path or config.compile_path
+  precompile(plugins)
   local compiled_loader = compile(plugins)
   output_path = vim.fn.expand(output_path)
   vim.fn.mkdir(vim.fn.fnamemodify(output_path, ":h"), 'p')

--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -369,6 +369,18 @@ packer.sync = function(...)
   end)()
 end
 
+
+local function reload_module(name)
+  if name then
+    package.loaded[name] = nil
+    return require(name)
+  end
+end
+
+--- Search through all the loaded packages for those that
+--- return a function, then cross reference them with all
+--- the plugin configs and setups and if there are any matches
+--- reload the user module.
 local function precompile(plugs)
   local reverse_index = {}
   for k, v in pairs(package.loaded) do
@@ -376,14 +388,11 @@ local function precompile(plugs)
         reverse_index[v] = k
     end
   end
-  -- TODO also reload setup as well as config
   for _, plugin in pairs(plugs) do
-    local value = plugin.config
-    local package_name = reverse_index[value]
-    if package_name then
-      package.loaded[package_name] = nil
-      require(package_name)
-    end
+    local cfg = reload_module(reverse_index[plugin.config])
+    local setup = reload_module(reverse_index[plugin.setup])
+    if cfg then plugin.config = cfg end
+    if setup then plugin.setup = setup end
   end
 end
 

--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -401,7 +401,8 @@ end
 packer.compile = function(output_path)
   output_path = output_path or config.compile_path
   precompile(plugins)
-  local compiled_loader = compile(plugins)
+  -- NOTE: we copy the plugins table so the in memory value is not mutated during compilation
+  local compiled_loader = compile(vim.deepcopy(plugins))
   output_path = vim.fn.expand(output_path)
   vim.fn.mkdir(vim.fn.fnamemodify(output_path, ":h"), 'p')
   local output_file = io.open(output_path, 'w')


### PR DESCRIPTION
This PR will fix #152 by automagically reloading any required configs in the packer startup call when compile is called.

@wbthomason this largely works as discussed except for one big caveat which is that the file where the user's plugins are specified needs to be reloaded (using luafile) before the change is picked up. From what I can tell the `precompile` (can change any names or relocate any functions) function correctly reloads the module but `compile` doesn't seem to actually rerun once packer is started up already i.e. it doesn't seem able to pick up any changes itself.


### Demo
You can't see my key presses unfortunately (don't have any good software for that), but I run packer compile then switch window

![packer-reload](https://user-images.githubusercontent.com/22454918/104487982-acbe4100-55c5-11eb-989c-3feb2f97561e.gif)


~I tried reloading the module where the user called `packer.startup` using `debug.getinfo()` to find the module name but that doesn't work and also seems brittle. Open to any suggestions~

## TODO
- [x] reload `setup` as well