### PR TITLE
Fix typos for lazy loading via functions

### DIFF
--- a/lua/packer/compile.lua
+++ b/lua/packer/compile.lua
@@ -279,7 +279,7 @@ local function make_loaders(_, plugins)
 
           for _, fn in ipairs(plugin.fn) do
             fns[fn] = fns[fn] or {}
-            table.insert(fns[fns], quote_name)
+            table.insert(fns[fn], quote_name)
           end
         end
       end
@@ -482,7 +482,7 @@ then
   vim.list_extend(result, keymap_defs)
   table.insert(result, '')
 
-  -- The filetype, event and func autocommands
+  -- The filetype, event and function autocommands
   table.insert(result, 'augroup packer_load_aucmds\n  au!')
   table.insert(result, '  " Filetype lazy-loads')
   vim.list_extend(result, ft_aucmds)
@@ -498,6 +498,6 @@ end
 
 local compile = setmetatable({cfg = cfg}, {__call = make_loaders})
 
-compile.opt_keys = {'after', 'cmd', 'ft', 'keys', 'event', 'cond', 'setup', 'func'}
+compile.opt_keys = {'after', 'cmd', 'ft', 'keys', 'event', 'cond', 'setup', 'fn'}
 
 return compile


### PR DESCRIPTION
I'm very sorry, but during the requested name changing of the variables from `func` to `fn` I forgot an occurrence (because it was a plain string) and another I adopted wrongly. 

Furthermore while using this new feature I discovered that autoload functions appear not to work. The `FuncUndefined` event does not get emitted for these. I hope that it is only a matter of escaping the `#` character and not a completely special treatment of autoload functions. I'll open a new PR for such a feature extension (if you wanna call it like that).