### PR TITLE
Escape problematic characters when lazy-loading mappings

### DIFF
--- a/lua/packer/compile.lua
+++ b/lua/packer/compile.lua
@@ -128,10 +128,8 @@ _packer_load = function(names, cause)
       vim.fn.feedkeys(prefix, 'n')
     end
 
-    local formatted_plug_key = string.format('%c%c%c', 0x80, 253, 83)
-    local keys = string.gsub(cause.keys, '^<Plug>', formatted_plug_key) .. extra
-    local escaped_keys = string.gsub(keys, '<[cC][rR]>', '\r')
-    vim.fn.feedkeys(escaped_keys)
+    local escaped_keys = vim.api.nvim_replace_termcodes(cause.keys .. extra, true, true, true)
+    vim.api.nvim_feedkeys(escaped_keys, 'm', true)
   elseif cause.event then
     vim.cmd(fmt('doautocmd <nomodeline> %s', cause.event))
   elseif cause.ft then
@@ -357,8 +355,7 @@ then
   for keymap, names in pairs(keymaps) do
     local prefix = nil
     if keymap[1] ~= 'i' then prefix = '' end
-    local escaped_map = string.gsub(keymap[2], '<[cC][rR]>', '\\<CR\\>')
-    escaped_map = string.gsub(escaped_map, '<Plug>', '\\<Plug\\>')
+    local escaped_map = string.gsub(keymap[2], '([\\"<>])', '\\%1')
 
     local keymap_line = fmt(
                           '%snoremap <silent> %s <cmd>call <SID>load([%s], { "keys": "%s"%s })<cr>',


### PR DESCRIPTION
This PR fixes the handling of the `keys` option.

- The `<` and `>` characters are escaped to prevent keycodes from being expanded. Fixes #147
- The `\` character is escaped to avoid accidentally expanding special characters. For example, `"\f"` expands to a formfeed in `expr-quote`s, when the user probably wants the literal characters "backslash f". Fixes #155
- The `"` can technically be used in a mapping, so I decided to escape it as well.

I've also decided to use `nvim_replace_termcodes()` instead of handling `<CR>` and `<Plug>` manually (I realize this was changed very recently in #153, sorry about that)

I made a very simple test plugin locally to ensure everything was working correctly:

<details>
<summary>plugins.lua</summary>

```lua
local packer = require('packer')

packer.startup(function(use)
    use 'wbthomason/packer.nvim'
    use {
        '~/Projects/dev/nvim_test_plugin',
        keys = {
            '<Plug>(testplug)',
            {'i', '<Plug>(testplug)'},
            'a',
            'y',
            '<C-j>',
            '<lt>',
            '>',
            '\\f',
            '\\|',
            '<LeftMouse>',
            '"',
        }
    }
end)
```

</details>

<details>
<summary>~Projects/dev/nvim_test_plugin/plugin/plugin.vim</summary>

```vim
map <Plug>(testplug) <Cmd>echomsg 'success: <lt>Plug>'<CR>
imap <Plug>(testplug) <Cmd>echomsg 'success: <lt>Plug>'<CR>
nnoremap a <Cmd>echomsg 'success: a'<CR>
nnoremap yos <Cmd>echomsg 'success: yos'<CR>
nnoremap <C-j> <Cmd>echomsg 'success: <lt>C-j>'<CR>
nnoremap <lt> <Cmd>echomsg 'success: <lt>lt>'<CR>
nnoremap > <Cmd>echomsg 'success: >'<CR>
nnoremap \f <Cmd>echomsg 'success: \f'<CR>
nnoremap \| <Cmd>echomsg 'success: <bar>'<CR>
nnoremap <LeftMouse> <Cmd>echomsg 'success: <lt>LeftMouse>'<CR>
nnoremap " <Cmd>echomsg 'success: "'<CR>
```

</details>

Everything seems to work as expected (though I would appreciate people testing this PR). Let me know if you have comments/concerns