### PR TITLE
Only try and remove disabled plugins that are installed

### DIFF
--- a/lua/packer/clean.lua
+++ b/lua/packer/clean.lua
@@ -13,7 +13,7 @@ local PLUGIN_OPTIONAL_LIST = 1
 local PLUGIN_START_LIST = 2
 
 local function is_dirty(plugin, typ)
-  return plugin.disable or (plugin.opt and typ == PLUGIN_START_LIST) or (not plugin.opt and typ == PLUGIN_OPTIONAL_LIST)
+  return (plugin.opt and typ == PLUGIN_START_LIST) or (not plugin.opt and typ == PLUGIN_OPTIONAL_LIST)
 end
 
 -- Find and remove any plugins not currently configured for use
@@ -46,9 +46,11 @@ local clean_plugins = function(_, plugins, results)
       end
 
       -- We don't want to report paths which don't exist for removal; that will confuse people
-      local plugin_missing = missing_plugins[plugin_config.short_name] and vim.loop.fs_stat(path)
+      local is_installed = vim.loop.fs_stat(path) ~= nil
+      local plugin_missing = missing_plugins[plugin_config.short_name] and is_installed
+      local disabled_but_installed = is_installed and plugin_config.disable
 
-      if plugin_missing or is_dirty(plugin_config, plugin_source) then
+      if plugin_missing or is_dirty(plugin_config, plugin_source) or disabled_but_installed then
         table.insert(dirty_plugins, path)
       end
     end


### PR DESCRIPTION
This relates a bit to #56. I read through that issue and so I'm hoping I didn't misunderstand how this is intended to work. @wbthomason mentions in that issue that `disable` should work similarly to a conditional i.e. if a plugin is disabled it should be removed and the declaration ignored generally as though it is in an if statement.

### Problem
If plugins are disabled they are picked up for cleaning *which is correct* as far as I understand. They are cleaned i.e. removed from the system. *Now for the problem*, __subsequent calls to PackerClean still try to remove these plugins__ even though they are no longer installed.

### Solution
`PackerClean` should not offer to remove things that do not exist on the system.

If you look carefully at this screen shot you will see that packer is offering to clean plugins that do not exist inside the directory shown in the terminal

![packer-disabled-clean](https://user-images.githubusercontent.com/22454918/104632118-24a76c80-5695-11eb-9cd8-6a03f5a92e27.png)

Since I'm not 100% certain I'm still not missing something, lemme know if maybe this is still the desired behaviour
