### PR TITLE
Auto reload packer compiled on compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ default configuration values (and structure of the configuration table) are:
   opt_default = false, -- Default to using opt (as opposed to start) plugins
   transitive_opt = true, -- Make dependencies of opt plugins also opt by default
   transitive_disable = true, -- Automatically disable dependencies of disabled plugins
+  auto_reload_compiled = true, -- Automatically reload the compiled file after creating it.
   git = {
     cmd = 'git', -- The base command for git operations
     subcommands = { -- Format strings for git subcommands

--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -33,6 +33,7 @@ local config_defaults = {
   opt_default = false,
   transitive_opt = true,
   transitive_disable = true,
+  auto_reload_compiled = true,
   git = {
     cmd = 'git',
     subcommands = {
@@ -408,6 +409,9 @@ packer.compile = function(output_path)
   local output_file = io.open(output_path, 'w')
   output_file:write(compiled_loader)
   output_file:close()
+  if config.auto_reload_compiled then
+    vim.cmd("source "..output_path)
+  end
   log.info('Finished compiling lazy-loaders!')
 end
 


### PR DESCRIPTION
This is a follow up to #158, now that required configs and setups are reloaded when packer compile is run, this pr adds a config-gated way to also automatically re-source the `packer_compiled.vim`. The config key I chose is `auto_reload_compiled` and defaults to `true` but I'm happy to change either.

I defaulted to `true` since I think/hope the vast majority of users have simple enough configs and they'd automatically get the benefit of things reloading without having to discover this option first and this could be an opt out for people with complex configs.

NOTE: this doesn't work with plugins that seem to be optional or lazy loaded, I haven't dug into the full compiled output but I'm guessing those plugins setups etc are skipped till they are loaded which is expected but also means that when they load they don't update 