### PR TITLE
Fix #165: escape spaces in the compile_path and package_root

### DIFF
--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -86,7 +86,8 @@ packer.init = function(user_config)
 
   packer.reset()
 
-  config.package_root = vim.fn.fnamemodify(config.package_root, ':p')
+  config.package_root = vim.fn.escape(vim.fn.fnamemodify(config.package_root, ':p'), ' ')
+  config.compile_path = vim.fn.escape(config.compile_path, ' ')
   local _
   config.package_root, _ = string.gsub(config.package_root, util.get_separator() .. '$', '', 1)
   config.pack_dir = util.join_paths(config.package_root, config.plugin_package)


### PR DESCRIPTION
Account for `package_root` and `compile_path` settings which may contain a space. If not escaped, this causes an error with `git` and other commands, per #165.