### PR TITLE
Expose packer plugins table

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,19 @@ use {
 }
 ```
 
+#### Checking plugin statuses
+You can check whether or not a particular plugin is installed with `packer` as well as if that plugin is loaded.
+To do this you can check for the plugin's name in the `packer_plugins` global table.
+Plugins in this table are saved using only the last section of their names
+e.g. `tpope/vim-fugitive` if installed will be under the key `vim-fugitive`.
+
+```lua
+if packer_plugins["vim-fugitive"] and packer_plugins["vim-fugitive"].loaded then
+print("Vim fugitive is loaded")
+-- other custom logic
+end
+```
+
 #### Luarocks support
 
 You may specify that a plugin requires one or more Luarocks packages using the `rocks` key. This key

--- a/doc/packer.txt
+++ b/doc/packer.txt
@@ -251,6 +251,18 @@ CONFIGURING PLUGINS                            *packer-plugin-configuration*
 `setup` key described in |packer.use()|) or after they are loaded (the
 `config` key described in |packer.use()|).
 
+PLUGIN STATUSES                                 *packer-plugin-status*
+You can check whether or not a particular plugin is installed with `packer` as
+well as if that plugin is loaded. To do this you can check for the plugin's
+name in the `packer_plugins` global table. Plugins in this table are saved
+using only the last section of their names e.g. `tpope/vim-fugitive` if
+installed will be under the key `vim-fugitive`.
+>
+  if packer_plugins["vim-fugitive"] and packer_plugins["vim-fugitive"].loaded then
+  print("Vim fugitive is loaded")
+  -- other custom logic
+  end
+
 CUSTOM INSTALLERS                              *packer-custom-installers*
 You may specify a custom installer & updater for a plugin using the
 `installer` and `updater` keys in a plugin specification. Note that either


### PR DESCRIPTION
This PR will fix #167 by exposing the packer plugins table as a `lua` global as `packer_plugins`. I chose to prefix it since `plugins` as a global seemed way too likely to clash with something.

A user can now do
```lua
if packer_plugins['coc.nvim'] and packer_plugins['coc.nvim'].loaded then
 print('Coc is Loaded!')
end
```

@wbthomason was this what you had in mind? 

Changes:
* Rename `plugins` -> `packer_plugins` I explictly used `_G` in the definition so it's clearer that this is intentional.
* If a plugin is `not opt` I set it's loaded value to true

I tested this locally and nothing *seemed* to be broken but would appreciate a second pair of eyes
Also this seems like it should be clearly documented somewhere but I don't know where. `vim-plug` has a wiki for these sort of tips and tricks, could also be in the readme 🤷🏿 ?

I'd suggest hiding whitespace changes so the change of indentation doesn't cause a bunch of noise during review