### PR TITLE
Add plugin update diff preview

### DIFF
--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -63,7 +63,7 @@ local config_defaults = {
     header_lines = 2,
     title = 'packer.nvim',
     show_all_info = true,
-    keybindings = {quit = 'q', toggle_info = '<CR>', prompt_revert = 'r'}
+    keybindings = {quit = 'q', toggle_info = '<CR>', diff = 'd', prompt_revert = 'r'}
   },
   luarocks = {python_cmd = 'python'}
 }

--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -42,6 +42,7 @@ local config_defaults = {
       current_branch = '-C %s rev-parse --abbrev-ref HEAD',
       diff = '-C %s log --color=never --pretty=format:FMT --no-show-signature HEAD@{1}...HEAD',
       diff_fmt = '%%h %%s (%%cr)',
+      git_diff_fmt = "-C %s diff %s~ %s",
       get_rev = '-C %s rev-parse --short HEAD',
       get_msg = '-C %s log --color=never --pretty=format:FMT --no-show-signature HEAD -n 1',
       submodules = '-C %s submodule update --init --recursive --progress',

--- a/lua/packer/display.lua
+++ b/lua/packer/display.lua
@@ -182,6 +182,11 @@ local display_mt = {
     vim.bo.buftype = "nofile"
     vim.bo.buflisted = false
     vim.api.nvim_buf_set_lines(0, 0, -1, false, lines)
+    vim.api.nvim_buf_set_keymap(0, "n", "q", "<cmd>pclose!<CR>", {
+      silent = true,
+      noremap = true,
+      nowait = true,
+    })
   end,
 
   --- Update the text of the headline message

--- a/lua/packer/display.lua
+++ b/lua/packer/display.lua
@@ -37,6 +37,10 @@ end
 local config = nil
 local keymaps = {
   quit = {rhs = '<cmd>lua require"packer.display".quit()<cr>', action = 'quit'},
+  diff = {
+    rhs = '<cmd>lua require"packer.display".diff()<cr>',
+    action = 'show the diff',
+  },
   toggle_info = {
     rhs = '<cmd>lua require"packer.display".toggle_info()<cr>',
     action = 'show more info'
@@ -49,7 +53,7 @@ local keymaps = {
 
 --- The order of the keys in a dict-like table isn't guaranteed, meaning the display window can
 --- potentially show the keybindings in a different order every time
-local keymap_display_order = {[1] = 'quit', [2] = 'toggle_info', [3] = 'prompt_revert'}
+local keymap_display_order = {[1] = 'quit', [2] = 'toggle_info', [3] = 'diff', [4] = 'prompt_revert'}
 
 --- Utility function to prompt a user with a question in a floating window
 local function prompt_user(headline, body, callback)
@@ -372,6 +376,25 @@ local display_mt = {
     end
   end,
 
+  diff = function (self)
+    if not self:valid_display() then return end
+    if next(self.plugins) == nil then
+      log.info('Operations are still running; plugin info is not ready yet')
+      return
+    end
+
+    local plugin_name, _ = self:find_nearest_plugin()
+    if plugin_name == nil then
+      log.warning('No plugin selected!')
+      return
+    end
+
+    local plugin_data = self.plugins[plugin_name]
+    print("plugin_data: " .. vim.inspect(plugin_data))
+    local diff = plugin_data.spec.diff()
+    print("diff: " .. vim.inspect(diff))
+  end,
+
   --- Prompt a user to revert the latest update for a plugin
   prompt_revert = function(self)
     if not self:valid_display() then return end
@@ -526,6 +549,9 @@ end
 
 display.toggle_info =
   function() if display.status.disp then display.status.disp:toggle_info() end end
+
+display.diff =
+  function() if display.status.disp then display.status.disp:diff() end end
 
 display.prompt_revert = function()
   if display.status.disp then display.status.disp:prompt_revert() end

--- a/lua/packer/display.lua
+++ b/lua/packer/display.lua
@@ -378,7 +378,7 @@ local display_mt = {
 
   diff = function (self)
     if not self:valid_display() then return end
-    if next(self.plugins) == nil then
+    if next(self.items) == nil then
       log.info('Operations are still running; plugin info is not ready yet')
       return
     end
@@ -389,7 +389,7 @@ local display_mt = {
       return
     end
 
-    local plugin_data = self.plugins[plugin_name]
+    local plugin_data = self.items[plugin_name]
     print("plugin_data: " .. vim.inspect(plugin_data))
     local diff = plugin_data.spec.diff()
     print("diff: " .. vim.inspect(diff))

--- a/lua/packer/display.lua
+++ b/lua/packer/display.lua
@@ -402,6 +402,11 @@ local display_mt = {
       return
     end
 
+    if not self.items[plugin_name] or not self.items[plugin_name].spec then
+      log.warn('Plugin not available!')
+      return
+    end
+
     local plugin_data = self.items[plugin_name].spec
     local commit_hash = plugin_data.revs[1]
     plugin_data.diff(commit_hash, function (diff, err)

--- a/lua/packer/display.lua
+++ b/lua/packer/display.lua
@@ -411,7 +411,7 @@ local display_mt = {
     local commit_hash = plugin_data.revs[1]
     plugin_data.diff(commit_hash, function (diff, err)
       if err then
-        return log.warn(err)
+        return log.warn('Unable to get diff!')
       end
       local lines = vim.split(diff[1], '\n')
       vim.schedule(function()

--- a/lua/packer/plugin_types/git.lua
+++ b/lua/packer/plugin_types/git.lua
@@ -318,8 +318,15 @@ git.setup = function(plugin)
     end)
   end
 
-  plugin.diff = function ()
-    
+  plugin.diff = function()
+    local r = result.ok(true)
+    async(function ()
+      local diff_cmd = vim.split(config.exec_cmd .. fmt(config.subcommands.diff, install_to), '%s+')
+      r = r:and_then(await, jobs.run(diff_cmd, {capture_output = true}))
+      return r
+    end)()
+    print("r: " .. vim.inspect(r))
+    return r
   end
 
   plugin.revert_last = function()

--- a/lua/packer/plugin_types/git.lua
+++ b/lua/packer/plugin_types/git.lua
@@ -318,6 +318,10 @@ git.setup = function(plugin)
     end)
   end
 
+  plugin.diff = function ()
+    
+  end
+
   plugin.revert_last = function()
     local r = result.ok(true)
     async(function()

--- a/lua/packer/plugin_types/git.lua
+++ b/lua/packer/plugin_types/git.lua
@@ -322,10 +322,17 @@ git.setup = function(plugin)
     local r = result.ok(true)
     async(function ()
       local diff_cmd = vim.split(config.exec_cmd .. fmt(config.subcommands.diff, install_to), '%s+')
-      r = r:and_then(await, jobs.run(diff_cmd, {capture_output = true}))
+      for i, arg in ipairs(messages_cmd) do
+        messages_cmd[i] = string.gsub(arg, 'FMT', config.subcommands.diff_fmt)
+      end
+      r = r:and_then(await, jobs.run(diff_cmd)):map_ok(function(value)
+        print("value: " .. vim.inspect(value))
+      end):map_err(function(err)
+        print("err: " .. vim.inspect(err))
+      end)
+      print("r: " .. vim.inspect(r))
       return r
     end)()
-    print("r: " .. vim.inspect(r))
     return r
   end
 


### PR DESCRIPTION
This PR adds the ability to view a diff of plugin changes when they are updated. It is similar to the `PlugDiff` command from `vim-plug`. So a user can see what bits of the code were changed. Fixes #78 


![packer_diff](https://user-images.githubusercontent.com/22454918/106180316-0e6cd680-6194-11eb-88a8-93eec16078a5.gif)