### PR TITLE
Diff command should show commit for the given line

### DIFF
--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -42,7 +42,7 @@ local config_defaults = {
       current_branch = '-C %s rev-parse --abbrev-ref HEAD',
       diff = '-C %s log --color=never --pretty=format:FMT --no-show-signature HEAD@{1}...HEAD',
       diff_fmt = '%%h %%s (%%cr)',
-      git_diff_fmt = "-C %s diff %s~ %s",
+      git_diff_fmt = "-C %s show --no-color --pretty=medium %s",
       get_rev = '-C %s rev-parse --short HEAD',
       get_msg = '-C %s log --color=never --pretty=format:FMT --no-show-signature HEAD -n 1',
       submodules = '-C %s submodule update --init --recursive --progress',

--- a/lua/packer/plugin_types/git.lua
+++ b/lua/packer/plugin_types/git.lua
@@ -321,7 +321,7 @@ git.setup = function(plugin)
   plugin.diff = function(commit, callback)
     async(function ()
       local r = result.ok(true)
-      local diff_cmd = config.exec_cmd .. fmt(config.subcommands.git_diff_fmt, install_to, commit, commit)
+      local diff_cmd = config.exec_cmd .. fmt(config.subcommands.git_diff_fmt, install_to, commit)
       local diff_info = {err = {}, output = {}, messages = {}}
       local diff_onread = jobs.logging_callback(diff_info.err, diff_info.messages)
       local diff_callbacks = {stdout = diff_onread, stderr = diff_onread}


### PR DESCRIPTION
This PR fixes a bug/enhances the changes in #183. Currently the `diff` command will show the first revision in the plugin's revisions which doesn't actually map to the changes shown for the update. This PR makes this functionality work exactly like the `PlugDiff` command in `vim-plug` i.e. hitting `d` on a given line show the diff *for that commit* as well as the commit message in full

![packer_diff](https://user-images.githubusercontent.com/22454918/106296417-8f39da00-6249-11eb-8eeb-2a9331b87591.gif)
