### PR TITLE
Remove unncessary string escapes

### DIFF
--- a/lua/packer/log.lua
+++ b/lua/packer/log.lua
@@ -88,7 +88,7 @@ log.new = function(config, standalone)
 
     local split_console = vim.split(console_string, "\n")
     for _, v in ipairs(split_console) do
-      vim.cmd(string.format([[echom "[%s] %s"]], config.plugin, vim.fn.escape(v, '"')))
+      vim.cmd(string.format([[echom "[%s] %s"]], config.plugin, v))
     end
 
     if config.highlights and level_config.hl then vim.cmd("echohl NONE") end


### PR DESCRIPTION
Currently, the string passed to `string.format` is escaped using `vim.fn.escape`.
Then the `string.format` will escape the resulting string too.
The result will be something like this.
`echom "[packer.nvim] [WARN  02:29:49] packer.lua:156: Plugin \\"telescope.nvim\\" is used twice!"`

This fixed it so that vim won't cause errors when printing logs.
