### PR TITLE
Various fixes related to keymap lazy-loading

### DIFF
--- a/lua/packer/compile.lua
+++ b/lua/packer/compile.lua
@@ -254,7 +254,8 @@ then
   for keymap, names in pairs(keymaps) do
     local prefix = nil
     if keymap[1] ~= 'i' then prefix = '' end
-    local escaped_map = string.gsub(keymap[2], '([\\"<>])', '\\%1')
+    local escaped_map_lt = string.gsub(keymap[2], '<', '<lt>')
+    local escaped_map = string.gsub(escaped_map_lt, '([\\"])', '\\%1')
     local keymap_line = fmt(
                           'vim.cmd [[%snoremap <silent> %s <cmd>lua require("packer.load")({%s}, { keys = "%s"%s }, _G.packer_plugins)<cr>]]',
                           keymap[1], keymap[2], table.concat(names, ', '), escaped_map,

--- a/lua/packer/compile.lua
+++ b/lua/packer/compile.lua
@@ -258,7 +258,7 @@ then
     local keymap_line = fmt(
                           'vim.cmd [[%snoremap <silent> %s <cmd>lua require("packer.load")({%s}, { keys = "%s"%s }, _G.packer_plugins)<cr>]]',
                           keymap[1], keymap[2], table.concat(names, ', '), escaped_map,
-                          prefix == nil and '' or (', "prefix": "' .. prefix .. '"'))
+                          prefix == nil and '' or (', prefix = "' .. prefix .. '"'))
 
     table.insert(keymap_defs, keymap_line)
   end


### PR DESCRIPTION
The changes introduced in e1aa188c2bf61c9a791df7fc3ccd3e59b946f3ce caused a few regressions:

- The `prefix` key for lazy-loading keymaps still used the syntax for Vim dictionaries
- Since the code now uses Lua strings, the `"\<"` and `"\>"` escape sequences are invalid. `<` characters have to be replaced with `<lt>`

Let me know if you have comments/concerns!