### PR TITLE
Add arguments to luarocks installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,7 +347,8 @@ end
 You may specify that a plugin requires one or more Luarocks packages using the `rocks` key. This key
 takes either a string specifying the name of a package (e.g. `rocks=lpeg`), or a list specifying one or more packages.
 Entries in the list may either be strings, a list of strings or a table --- the latter case is used to specify arguments such as the
-particular version of a package, e.g.
+particular version of a package.
+Supported lua rocks keys are: `server`, `only_server`, `only-sources`
 ```lua
 rocks = {'lpeg', {'lua-cjson', version = '2.1.0'}}
 use_rocks {'lua-cjson', 'lua-resty-http'}

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ return require('packer').startup(function()
   -- Plugins can also depend on rocks from luarocks.org:
   use {
     'my/supercoolplugin',
-    rocks = {'lpeg', {'lua-cjson', '2.1.0'}}
+    rocks = {'lpeg', {'lua-cjson', version = '2.1.0'}}
   }
 
   -- You can specify rocks in isolation
@@ -346,8 +346,13 @@ end
 
 You may specify that a plugin requires one or more Luarocks packages using the `rocks` key. This key
 takes either a string specifying the name of a package (e.g. `rocks=lpeg`), or a list specifying one or more packages.
-Entries in the list may either be strings or lists --- the latter case is used to specify a
-particular version of a package, e.g. `rocks = {'lpeg', {'lua-cjson', '2.1.0'}}`.
+Entries in the list may either be strings, a list of strings or a table --- the latter case is used to specify arguments such as the
+particular version of a package, e.g.
+```lua
+rocks = {'lpeg', {'lua-cjson', version = '2.1.0'}}
+use_rocks {'lua-cjson', 'lua-resty-http'}
+use_rocks {'luaformatter', server = 'https://luarocks.org/dev'}
+```
 
 Currently, `packer` only supports equality constraints on package versions.
 

--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -112,9 +112,13 @@ end
 --- Add a Luarocks package to be managed
 local function use_rocks(rock)
   if type(rock) == 'string' then rock = {rock} end
-  for _, r in ipairs(rock) do
-    local rock_name = (type(r) == 'table') and r[1] or r
-    rocks[rock_name] = r
+  if not vim.tbl_islist(rock) and type(rock[1]) == "string" then
+    rocks[rock[1]] = rock
+  else
+    for _, r in ipairs(rock) do
+      local rock_name = (type(r) == 'table') and r[1] or r
+      rocks[rock_name] = r
+    end
   end
 end
 

--- a/lua/packer/luarocks.lua
+++ b/lua/packer/luarocks.lua
@@ -399,7 +399,11 @@ local function ensure_packages(rocks, results, disp)
         local spec = to_install[package.name]
         if spec then
           if type(spec) == 'table' then
-            if spec.version == package.version then to_install[package.name] = nil end
+            -- if the package is on the system and the spec has no version
+            -- or it has a version and that is the version on the system do not install it again
+            if not spec.version or (spec.version and spec.version == package.version) then
+              to_install[package.name] = nil
+            end
           else
             to_install[package.name] = nil
           end

--- a/lua/packer/luarocks.lua
+++ b/lua/packer/luarocks.lua
@@ -327,7 +327,11 @@ local function clean_packages(rocks, results, disp)
       local to_remove = {}
       for _, package in ipairs(installed_packages) do to_remove[package.name] = package end
       for _, rock in pairs(rocks) do
-        if type(rock) == 'table' then
+        if vim.tbl_islist(rock) then
+          for _,name in ipairs(rock) do
+            to_remove[name] = nil
+          end
+        elseif type(rock) == 'table' then
           if to_remove[rock[1]] and (not rock.version or to_remove[rock[1]].version == rock.version) then
             to_remove[rock[1]] = nil
           end
@@ -386,7 +390,11 @@ local function ensure_packages(rocks, results, disp)
   return async(function()
     local to_install = {}
     for _, rock in pairs(rocks) do
-      if type(rock) == 'table' then
+      if vim.tbl_islist(rock) then
+        for _,name in ipairs(rock) do
+          to_install[name] = name
+        end
+      elseif type(rock) == 'table' then
         to_install[rock[1]] = rock
       else
         to_install[rock] = true

--- a/lua/packer/luarocks.lua
+++ b/lua/packer/luarocks.lua
@@ -170,7 +170,7 @@ local luarocks_keys = {
 }
 
 local function format_luarocks_args(package)
-  if vim.tbl_islist(package) or type(package) ~= 'table' then return '' end
+  if type(package) ~= 'table' then return '' end
   local args = {}
   for key, value in pairs(package) do
     local luarock_key = luarocks_keys[key]
@@ -327,11 +327,7 @@ local function clean_packages(rocks, results, disp)
       local to_remove = {}
       for _, package in ipairs(installed_packages) do to_remove[package.name] = package end
       for _, rock in pairs(rocks) do
-        if vim.tbl_islist(rock) then
-          for _,name in ipairs(rock) do
-            to_remove[name] = nil
-          end
-        elseif type(rock) == 'table' then
+        if type(rock) == 'table' then
           if to_remove[rock[1]] and (not rock.version or to_remove[rock[1]].version == rock.version) then
             to_remove[rock[1]] = nil
           end
@@ -390,11 +386,7 @@ local function ensure_packages(rocks, results, disp)
   return async(function()
     local to_install = {}
     for _, rock in pairs(rocks) do
-      if vim.tbl_islist(rock) then
-        for _,name in ipairs(rock) do
-          to_install[name] = name
-        end
-      elseif type(rock) == 'table' then
+      if type(rock) == 'table' then
         to_install[rock[1]] = rock
       else
         to_install[rock] = true


### PR DESCRIPTION
This PR will hopefully eventually add argument keys to `use_rocks` to be passed on to luarocks during installation.
There are currently a few bugs/kinks to work out/ a potentially breaking change for any early adopters.

Currently the API for specifying luarocks allows specifying the version of a rock as
```lua
use_rocks {"cjson", "2.1.0"}
user_rocks {"cjson", "penlight"}
```
I might have misunderstood the intended patterns for usage but the above 2 patterns are in conflict short of using a regex or something to detect that one of the two patterns includes a version number.

### Example of such an issue (attempts to install `2.1.0`)
![packer-version-bug](https://user-images.githubusercontent.com/22454918/107702554-51f63300-6cb2-11eb-823d-6315da199272.png)

@wbthomason would appreciate some input on how this API should work, in this PR I've tested moving the version specification to an explicit key, since it makes things clearer and allows listing strings to work since it doesn't have to consider that a list of strings might contain a version

#### TODO
- [x] Fix incorrectly re-installing already installed plugins
- [x] Check for potential breakages in other code paths