### PR TITLE
Feature: autogenerate profiling code for packer_compiled

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,10 @@ Have a problem or idea? Make an [issue](https://github.com/wbthomason/packer.nvi
     4. [Performing plugin management operations](#performing-plugin-management-operations)
     5. [Extending packer](#extending-packer)
     6. [Compiling Lazy-Loaders](#compiling-lazy-loaders)
-7. [Debugging](#debugging)
-8. [Status](#status)
-9. [Contributors](#contributors)
+7. [Profiling](#profiling)
+8. [Debugging](#debugging)
+9. [Status](#status)
+10. [Contributors](#contributors)
 
 ## Notices
 - **2021-02-18**: Having trouble with Luarocks on macOS? See [this issue](https://github.com/wbthomason/packer.nvim/issues/180).
@@ -283,6 +284,10 @@ default configuration values (and structure of the configuration table) are:
   },
   luarocks = {
     python_cmd = 'python' -- Set the python command to use for running hererocks
+  },
+  profile = {
+    enable = false,
+    threshold = 1, -- integer in milliseconds, plugins which load faster than this won't be shown in profile output
   }
 }
 ```
@@ -483,6 +488,33 @@ require knowing when the operations are complete, you can use the following `Use
 
 - `PackerComplete`: Fires after install, update, clean, and sync asynchronous operations finish.
 - `PackerCompileDone`: Fires after compiling (see [the section on compilation](#compiling-lazy-loaders))
+
+## Profiling
+Packer has built in functionality that can allow you to profile the time taken loading your plugins.
+In order to use this functionality you must either enable profiling in your config, or pass in an argument
+when running packer compile.
+
+#### Setup via config
+```lua
+config = {
+  profile = {
+    enable = true,
+    threshold = 1 -- the amount in ms that a plugins load time must be over for it to be included in the profile
+  }
+}
+```
+
+#### Using the packer compile command
+```vim
+:PackerCompile profile=true
+" or
+:PackerCompile profile=false
+```
+
+#### Profiling usage
+This will rebuild your `packer_compiled.vim` with profiling code included. In order to visualise the output of the profile
+restart your neovim and run `PackerProfile`. This will open a window with the output of your profiling.
+
 ## Debugging
 `packer.nvim` logs to `stdpath(cache)/packer.nvim.log`. Looking at this file is usually a good start
 if something isn't working as expected.

--- a/doc/packer.txt
+++ b/doc/packer.txt
@@ -374,6 +374,36 @@ The option `compile_on_sync`, which defaults to `true`, will run
 Note that otherwise, you **must** run `packer.compile` yourself to generate
 the lazy-loader file!
 
+PROFILING PLUGINS                              *packer-profiling*
+You can measure how long it takes your plugins to load using packer's builtin
+profiling functionality.
+In order to use this functionality you must either enable profiling in your config, or pass in an argument
+when running packer compile.
+
+Setup via config >
+  config = {
+    profile = {
+      enable = true,
+      threshold = 1 -- the amount in ms that a plugins load time must be over for it to be included in the profile
+    }
+  }
+<
+
+Using the packer compile command
+>
+  :PackerCompile profile=true
+  " or
+  :PackerCompile profile=false
+<
+
+NOTE you can also set a `threshold` in your profile config which is a number
+in `ms` above which plugin load times will be show e.g. if you set a threshold
+value of `3` then any plugin that loads slower than `3ms` will not be included in
+the output window.
+
+This will rebuild your `packer_compiled.vim` with profiling code included. In order to visualise the output of the profile
+Restart your neovim and run `PackerProfile`. This will open a window with the output of your profiling.
+
 EXTENDING PACKER                               *packer-extending*
 You can add custom key handlers to `packer` by calling
 `packer.set_handler(name, func)` where `name` is the key you wish to handle

--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -16,6 +16,11 @@ local util = require('packer.util')
 local async = a.sync
 local await = a.wait
 
+--- Instantiate global packer namespace for use for
+--- callbacks and other data generated whilst packer
+--- is running
+_G._packer = {}
+
 -- Config
 local packer = {}
 local config_defaults = {
@@ -444,6 +449,15 @@ packer.compile = function(output_path)
   if config.auto_reload_compiled then vim.cmd("source " .. output_path) end
   log.info('Finished compiling lazy-loaders!')
   packer.on_compile_done()
+end
+
+packer.profile_output = function ()
+  if _G._packer.profile_output then
+    async(function()
+      local display_win = display.open(config.display.open_fn or config.display.open_cmd)
+      display_win:profile_output(_G._packer.profile_output)
+    end)()
+  end
 end
 
 packer.config = config

--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -73,9 +73,7 @@ local config_defaults = {
   },
   luarocks = {python_cmd = 'python'},
   log = {level = 'warn'},
-  profile = {
-    enabled = false
-  }
+  profile = {enabled = false}
 }
 
 local config = vim.tbl_extend('force', {}, config_defaults)
@@ -439,24 +437,21 @@ local function refresh_configs(plugs)
 end
 
 local function parse_value(value)
-  if value == "true" then
-    return true
-  end
-  if value == "false" then
-    return false
-  end
+  if value == "true" then return true end
+  if value == "false" then return false end
   return value
 end
 
 local function parse_args(args)
   local result = {}
-  if not args then return result end
-  local parts = vim.split(args, ' ')
-  for _, part in ipairs(parts) do
-    if part then
-      if part:find('=') then
-        local key, value = unpack(vim.split(part, '='))
-        result[key] = parse_value(value)
+  if args then
+    local parts = vim.split(args, ' ')
+    for _, part in ipairs(parts) do
+      if part then
+        if part:find('=') then
+          local key, value = unpack(vim.split(part, '='))
+          result[key] = parse_value(value)
+        end
       end
     end
   end
@@ -471,9 +466,7 @@ packer.compile = function(raw_args)
   local should_profile = args.profile
   -- the user might explicitly choose for this value to be false in which case
   -- an or operator will not work
-  if should_profile == nil then
-    should_profile = config.profile.enabled
-  end
+  if should_profile == nil then should_profile = config.profile.enabled end
   refresh_configs(plugins)
   -- NOTE: we copy the plugins table so the in memory value is not mutated during compilation
   local compiled_loader = compile(vim.deepcopy(plugins), should_profile)
@@ -487,7 +480,7 @@ packer.compile = function(raw_args)
   packer.on_compile_done()
 end
 
-packer.profile_output = function ()
+packer.profile_output = function()
   if _G._packer.profile_output then
     async(function()
       local display_win = display.open(config.display.open_fn or config.display.open_cmd)

--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -109,6 +109,7 @@ packer.init = function(user_config)
     vim.cmd [[command! PackerClean    lua require('packer').clean()]]
     vim.cmd [[command! -nargs=* PackerCompile  lua require('packer').compile(<q-args>)]]
     vim.cmd [[command! PackerStatus  lua require('packer').status()]]
+    vim.cmd [[command! PackerProfile  lua require('packer').profile_output()]]
   end
 end
 

--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -19,7 +19,7 @@ local await = a.wait
 --- Instantiate global packer namespace for use for
 --- callbacks and other data generated whilst packer
 --- is running
-_G._packer = {}
+_G._packer = _G._packer or {}
 
 -- Config
 local packer = {}

--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -73,7 +73,7 @@ local config_defaults = {
   },
   luarocks = {python_cmd = 'python'},
   log = {level = 'warn'},
-  profile = {enabled = false}
+  profile = {enable = false}
 }
 
 local config = vim.tbl_extend('force', {}, config_defaults)
@@ -466,7 +466,7 @@ packer.compile = function(raw_args)
   local should_profile = args.profile
   -- the user might explicitly choose for this value to be false in which case
   -- an or operator will not work
-  if should_profile == nil then should_profile = config.profile.enabled end
+  if should_profile == nil then should_profile = config.profile.enable end
   refresh_configs(plugins)
   -- NOTE: we copy the plugins table so the in memory value is not mutated during compilation
   local compiled_loader = compile(vim.deepcopy(plugins), should_profile)
@@ -486,6 +486,8 @@ packer.profile_output = function()
       local display_win = display.open(config.display.open_fn or config.display.open_cmd)
       display_win:profile_output(_G._packer.profile_output)
     end)()
+  else
+    log.warn('You must run PackerCompile with profiling enabled first e.g. PackerProfile profile=true')
   end
 end
 

--- a/lua/packer/compile.lua
+++ b/lua/packer/compile.lua
@@ -66,9 +66,8 @@ local function save_profiles(threshold)
     end
   end
 
-  if _G._packer then
-    _G._packer.profile_output = results
-  end
+  _G._packer = _G._packer or {}
+  _G._packer.profile_output = results
 end
 ]]
 

--- a/lua/packer/compile.lua
+++ b/lua/packer/compile.lua
@@ -66,7 +66,9 @@ local function save_profiles(threshold)
     end
   end
 
-  _G._packer.profile_output = results
+  if _G._packer then
+    _G._packer.profile_output = results
+  end
 end
 ]]
 

--- a/lua/packer/compile.lua
+++ b/lua/packer/compile.lua
@@ -54,13 +54,13 @@ local function print_profiles()
   for chunk_name, time_taken in pairs(profile_info) do
     sorted_times[#sorted_times + 1] = {chunk_name, time_taken}
   end
-  table.sort(sorted_times, function(a, b) return a[2] < b[2] end)
+  table.sort(sorted_times, function(a, b) return a[2] > b[2] end)
   local results = {}
   for i, elem in ipairs(sorted_times) do
     results[i] = elem[1] .. ' took ' .. elem[2] .. 'ms'
   end
 
-  print(vim.inspect(results))
+  _G._packer.profile_output = results
 end
 ]]
 
@@ -416,7 +416,7 @@ local function make_loaders(_, plugins)
     end
 
     local conditional = [[if
-  ]] .. timed_chunk(executable_conditional, 'Conditional: ' .. executable_conditional) .. [[
+  ]] .. vim.inspect(timed_chunk(executable_conditional, 'Conditional: ' .. executable_conditional) ~= nil) .. [[
 
 then
 ]] .. table.concat(conditional_loads, '\n\t') .. '\nend\n'

--- a/lua/packer/display.lua
+++ b/lua/packer/display.lua
@@ -592,13 +592,20 @@ local function make_filetype_cmds(working_sym, done_sym, error_sym)
     'syn match packerHash /\\(\\s\\)[0-9a-f]\\{7,8}\\(\\s\\)/',
     'syn match packerRelDate /([^)]*)$/', 'syn match packerProgress /\\(\\[\\)\\@<=[\\=]*/',
     'syn match packerOutput /\\(Output:\\)\\|\\(Commits:\\)\\|\\(Errors:\\)/',
+    [[syn match packerTimeHigh /\d\{3\}\.\d\+ms/]],
+    [[syn match packerTimeMedium /\d\{2\}\.\d\+ms/]],
+    [[syn match packerTimeLow /\d\.\d\+ms/]],
+    [[syn match packerTimeTrivial /0\.\d\+ms/]],
     [[syn match packerPackageNotLoaded /(not loaded)$/]],
     [[syn match packerPackageName /\(^\ • \)\@<=[^ ]*/]],
     [[syn match packerString /\v(''|""|(['"]).{-}[^\\]\2)/]],
-    [[syn match packerBool /\<\(false\|true\)\>/]], 'hi def link packerWorking        SpecialKey',
-    'hi def link packerSuccess        Question', 'hi def link packerFail           ErrorMsg',
-    'hi def link packerHash           Identifier', 'hi def link packerRelDate        Comment',
-    'hi def link packerProgress       Boolean', 'hi def link packerOutput         Type'
+    [[syn match packerBool /\<\(false\|true\)\>/]],
+    'hi def link packerWorking        SpecialKey', 'hi def link packerSuccess        Question',
+    'hi def link packerFail           ErrorMsg', 'hi def link packerHash           Identifier',
+    'hi def link packerRelDate        Comment', 'hi def link packerProgress       Boolean',
+    'hi def link packerOutput         Type', 'hi def link packerTimeHigh WarningMsg',
+    'hi def link packerTimeMedium Float', 'hi def link packerTimeLow String',
+    'hi def link packerTimeTrivial Comment',
   }
 end
 

--- a/lua/packer/display.lua
+++ b/lua/packer/display.lua
@@ -463,10 +463,11 @@ local display_mt = {
   end,
 
   profile_output = function (self, output)
+    local result = {}
     for i, line in ipairs(output) do
-      output[i] = string.rep(" ", 2) .. line
+      result[i] = string.rep(" ", 2) .. line
     end
-    self:set_lines(config.header_lines, -1, output)
+    self:set_lines(config.header_lines, -1, result)
   end,
 
   --- Toggle the display of detailed information for a plugin in the final results display

--- a/lua/packer/display.lua
+++ b/lua/packer/display.lua
@@ -267,6 +267,14 @@ local display_mt = {
     for _, c in ipairs(highlights) do vim.cmd(c) end
   end,
 
+  setup_profile_syntax = function (_)
+    local highlights = {
+      'hi def link packerTimeHigh WarningMsg', 'hi def link packerTimeMedium Float',
+      'hi def link packerTimeLow String', 'hi def link packerTimeTrivial Comment'
+    }
+    for _, c in ipairs(highlights) do vim.cmd(c) end
+  end,
+
   status = vim.schedule_wrap(function(self, plugins)
     if not self:valid_display() then return end
     self:setup_status_syntax()
@@ -463,6 +471,7 @@ local display_mt = {
   end,
 
   profile_output = function (self, output)
+    self:setup_profile_syntax()
     local result = {}
     for i, line in ipairs(output) do
       result[i] = string.rep(" ", 2) .. line
@@ -604,9 +613,7 @@ local function make_filetype_cmds(working_sym, done_sym, error_sym)
     'hi def link packerWorking        SpecialKey', 'hi def link packerSuccess        Question',
     'hi def link packerFail           ErrorMsg', 'hi def link packerHash           Identifier',
     'hi def link packerRelDate        Comment', 'hi def link packerProgress       Boolean',
-    'hi def link packerOutput         Type', 'hi def link packerTimeHigh WarningMsg',
-    'hi def link packerTimeMedium Float', 'hi def link packerTimeLow String',
-    'hi def link packerTimeTrivial Comment',
+    'hi def link packerOutput         Type'
   }
 end
 

--- a/lua/packer/display.lua
+++ b/lua/packer/display.lua
@@ -462,6 +462,13 @@ local display_mt = {
     end
   end,
 
+  profile_output = function (self, output)
+    for i, line in ipairs(output) do
+      output[i] = string.rep(" ", 2) .. line
+    end
+    self:set_lines(config.header_lines, -1, output)
+  end,
+
   --- Toggle the display of detailed information for a plugin in the final results display
   toggle_info = function(self)
     if not self:valid_display() then return end


### PR DESCRIPTION
This PR adds timing code wrapping each "chunk" of the compiled output, which runs iff the environment variable PACKER_PROFILE is present and true. This allows a simple output of timing information for each part of the compiled loaders.

This is still WIP. The main things it needs are:
- [x] Define the `timed_chunk` function, which is simple except for figuring out what name to use for each chunk
- [x] Improve output formatting
- [ ] Add line numbers to output
- [x] Sort output by time
- ~[ ] Concatenate output to compiled file~
- [x] Maybe add output only for chunks over some threshold of time?

Pinging @akinsho re: discussion on #191.