### PR TITLE
Allow env key and more luarocks arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,11 +341,13 @@ You may specify that a plugin requires one or more Luarocks packages using the `
 takes either a string specifying the name of a package (e.g. `rocks=lpeg`), or a list specifying one or more packages.
 Entries in the list may either be strings, a list of strings or a table --- the latter case is used to specify arguments such as the
 particular version of a package.
-Supported lua rocks keys are: `server`, `only_server`, `only-sources`
+all supported luarocks keys are allowed except: `tree` and `local`. Environment variables for the luarocks command can also be
+specified using the `env` key which takes a table as the value as shown below.
 ```lua
 rocks = {'lpeg', {'lua-cjson', version = '2.1.0'}}
 use_rocks {'lua-cjson', 'lua-resty-http'}
 use_rocks {'luaformatter', server = 'https://luarocks.org/dev'}
+use_rocks {'openssl' env = {OPENSSL_DIR = "/path/to/dir"}}
 ```
 
 Currently, `packer` only supports equality constraints on package versions.

--- a/lua/packer/luarocks.lua
+++ b/lua/packer/luarocks.lua
@@ -176,16 +176,16 @@ local function format_luarocks_args(package)
   if type(package) ~= 'table' then return '' end
   local args = {}
   for key, value in pairs(package) do
-    if type(key) ~= "string" or not is_valid_luarock_key(key) then goto continue end
-    local luarock_key = luarocks_keys[key] and luarocks_keys[key] or key
-    if luarock_key and type(value) == 'string' then
-      table.insert(args, string.format('--%s=%s', key, value))
-    elseif key == "env" and type(value) == "table" then
-      for name, env_value in pairs(value) do
-        table.insert(args, string.format('%s=%s', name, env_value))
+    if type(key) == "string" and is_valid_luarock_key(key) then
+      local luarock_key = luarocks_keys[key] and luarocks_keys[key] or key
+      if luarock_key and type(value) == 'string' then
+        table.insert(args, string.format('--%s=%s', key, value))
+      elseif key == "env" and type(value) == "table" then
+        for name, env_value in pairs(value) do
+          table.insert(args, string.format('%s=%s', name, env_value))
+        end
       end
     end
-    ::continue::
   end
   return ' ' ..table.concat(args, ' ')
 end

--- a/lua/packer/luarocks.lua
+++ b/lua/packer/luarocks.lua
@@ -166,17 +166,26 @@ end
 local luarocks_keys = {
   only_server = 'only-server',
   only_source = 'only-sources',
-  server = 'server'
 }
+
+local function is_valid_luarock_key(key)
+  return not (key == 'tree' or key == 'local')
+end
 
 local function format_luarocks_args(package)
   if type(package) ~= 'table' then return '' end
   local args = {}
   for key, value in pairs(package) do
-    local luarock_key = luarocks_keys[key]
+    if type(key) ~= "string" or not is_valid_luarock_key(key) then goto continue end
+    local luarock_key = luarocks_keys[key] and luarocks_keys[key] or key
     if luarock_key and type(value) == 'string' then
       table.insert(args, string.format('--%s=%s', key, value))
+    elseif key == "env" and type(value) == "table" then
+      for name, env_value in pairs(value) do
+        table.insert(args, string.format('%s=%s', name, env_value))
+      end
     end
+    ::continue::
   end
   return ' ' ..table.concat(args, ' ')
 end


### PR DESCRIPTION
@wbthomason, this resolves the issue raised in gitter and discussed in #187. It allows specifying an `env` key for `luarocks` so you can pass arguments such as `OPENSSL_DIR` for the `openssl` rock, as an example.
```lua
 use_rocks {"openssl", env = {OPENSSL_DIR = "<value>"}}
```
@clason could you try this branch out and see if it does what you need.