### PR TITLE
Fix compilation when there are multple rtp settings

### DIFF
--- a/lua/packer/compile.lua
+++ b/lua/packer/compile.lua
@@ -285,9 +285,9 @@ local function make_loaders(_, plugins)
   end
 
   local rtp_line = ''
-  for _, rtp in ipairs(rtps) do rtp_line = rtp_line .. '",' .. vim.fn.escape(rtp, '\\,') .. '"' end
+  for _, rtp in ipairs(rtps) do rtp_line = rtp_line .. ' .. ",' .. vim.fn.escape(rtp, '\\,') .. '"' end
 
-  if rtp_line ~= '' then rtp_line = 'vim.o.runtimepath = vim.o.runtimepath .. ' .. rtp_line end
+  if rtp_line ~= '' then rtp_line = 'vim.o.runtimepath = vim.o.runtimepath' .. rtp_line end
 
   local setup_lines = {}
   for name, plugin_setup in pairs(setup) do


### PR DESCRIPTION
When there are multiple plugins defined with `rtp`, the compiler was concatenating the path strings directly. This is a simple fix to add the string concatenation operator.
