### PR TITLE
Lazy load package on require

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,7 @@ use {
   fn = string or list          -- Specifies functions which load this plugin.
   cond = string, function, or list of strings/functions,   -- Specifies a conditional test to load this plugin
   setup = string or function,  -- Specifies code to run before this plugin is loaded.
+  module = string or list      -- Specifies patterns (e.g. for string.match) of Lua module names which, when required, load this plugin
 }
 ```
 
@@ -492,6 +493,7 @@ Many thanks to those who have contributed to the project! PRs and issues are alw
 list is infrequently updated; please feel free to bug me if you're not listed here and you would
 like to be.
 
+- @akinsho
 - @nanotee
 - @weilbith
 - @Iron-E
@@ -501,7 +503,6 @@ like to be.
 - @gbrlsnchs
 - @lewis6991
 - @TimUntersberger
-- @akinsho
 - @bfredl
 - @sunjon
 - @gwerbin

--- a/doc/packer.txt
+++ b/doc/packer.txt
@@ -478,6 +478,7 @@ invoked as follows:
     fn = string or list          -- Specifies functions which load this plugin.
     cond = string, function, or list of strings/functions,   -- Specifies a conditional test to load this plugin
     setup = string or function,  -- Specifies code to run before this plugin is loaded.
+    module = string or list      -- Specifies patterns (e.g. for string.match) of Lua module names which, when required, load this plugin
   }
 - With a list of plugins specified in either of the above two forms
 

--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -74,14 +74,32 @@ local config = vim.tbl_extend('force', {}, config_defaults)
 local plugins = nil
 local rocks = nil
 
+local function lazy_load_module(module_name)
+  for name, plugin in pairs(plugins) do
+    local formatted = vim.fn.matchstr(module_name, [[^[^./]\+]])
+    if plugin.module == formatted and not plugin.loaded then
+      vim.cmd('packadd ' .. name)
+      plugin.loaded = true
+    end
+  end
+end
+
+local function append_loader()
+    return function(mod_name)
+      lazy_load_module(mod_name)
+      return nil
+    end
+end
+
 --- Initialize packer
 -- Forwards user configuration to sub-modules, resets the set of managed plugins, and ensures that
 -- the necessary package directories exist
 packer.init = function(user_config)
   user_config = user_config or {}
   config = util.deep_extend('force', config, user_config)
-
   packer.reset()
+
+  table.insert(package.loaders, 1, append_loader())
 
   config.package_root = vim.fn.fnamemodify(config.package_root, ':p')
   local _

--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -74,23 +74,6 @@ local config = vim.tbl_extend('force', {}, config_defaults)
 local plugins = nil
 local rocks = nil
 
-local function lazy_load_module(module_name)
-  for name, plugin in pairs(plugins) do
-    local formatted = vim.fn.matchstr(module_name, [[^[^./]\+]])
-    if plugin.module == formatted and not plugin.loaded then
-      vim.cmd('packadd ' .. name)
-      plugin.loaded = true
-    end
-  end
-end
-
-local function append_loader()
-    return function(mod_name)
-      lazy_load_module(mod_name)
-      return nil
-    end
-end
-
 --- Initialize packer
 -- Forwards user configuration to sub-modules, resets the set of managed plugins, and ensures that
 -- the necessary package directories exist
@@ -98,9 +81,6 @@ packer.init = function(user_config)
   user_config = user_config or {}
   config = util.deep_extend('force', config, user_config)
   packer.reset()
-
-  table.insert(package.loaders, 1, append_loader())
-
   config.package_root = vim.fn.fnamemodify(config.package_root, ':p')
   local _
   config.package_root, _ = string.gsub(config.package_root, util.get_separator() .. '$', '', 1)

--- a/lua/packer/compile.lua
+++ b/lua/packer/compile.lua
@@ -56,7 +56,7 @@ local function lazy_load_module(module_name)
 end
 
 if not vim.g.packer_custom_loader_enabled then
-  table.insert(package.loaders, 1, lazy_load_module)
+  table.insert(package.loaders, 2, lazy_load_module)
   vim.g.packer_custom_loader_enabled = true
 end
 ]]

--- a/lua/packer/compile.lua
+++ b/lua/packer/compile.lua
@@ -46,13 +46,19 @@ local function lazy_load_module(module_name)
   local to_load = {}
   local i = 1
   for module_pat, plugin_name in pairs(module_lazy_loads) do
-    if string.match(module_name, "^" .. module_pat) then to_load[i] = plugin_name end
+    -- check the plugin has not already been loaded to avoid an infinite loop
+    if string.match(module_name, "^" .. module_pat) and not _G.packer_plugins[plugin_name].loaded then
+      to_load[i] = plugin_name
+    end
   end
 
   require('packer.load')(to_load, {module = module_name}, _G.packer_plugins)
 end
 
-table.insert(package.loaders, 1, lazy_load_module)
+if not vim.g.packer_custom_loader_enabled then
+  table.insert(package.loaders, 1, lazy_load_module)
+  vim.g.packer_custom_loader_enabled = true
+end
 ]]
 
 local function dump_loaders(loaders)

--- a/lua/packer/compile.lua
+++ b/lua/packer/compile.lua
@@ -207,8 +207,8 @@ local function make_loaders(_, plugins)
         end
 
         for _, event in ipairs(plugin.event) do
-          if event:sub(#event,-1) ~= '*' and not event:find('%s') then
-            event = event ..' *'
+          if event:sub(#event, -1) ~= '*' and not event:find('%s') then
+            event = event .. ' *'
           end
           events[event] = events[event] or {}
           table.insert(events[event], quote_name)
@@ -272,9 +272,7 @@ local function make_loaders(_, plugins)
       if plugin.fn then
         loaders[name].only_sequence = false
         loaders[name].only_setup = false
-
         if type(plugin.fn) == 'string' then plugin.fn = {plugin.fn} end
-
         for _, fn in ipairs(plugin.fn) do
           fns[fn] = fns[fn] or {}
           table.insert(fns[fn], quote_name)
@@ -473,6 +471,7 @@ then
     table.insert(result, module_loader)
   end
 
+  -- Then setups, configs, and conditionals
   if next(setup_lines) then vim.list_extend(result, setup_lines) end
   if next(config_lines) then vim.list_extend(result, config_lines) end
   if next(conditionals) then

--- a/lua/packer/compile.lua
+++ b/lua/packer/compile.lua
@@ -46,7 +46,7 @@ local function lazy_load_module(module_name)
   local to_load = {}
   local i = 1
   for module_pat, plugin_name in pairs(module_lazy_loads) do
-    if string.match(module_name, module_pat) then to_load[i] = plugin_name end
+    if string.match(module_name, "^" .. module_pat) then to_load[i] = plugin_name end
   end
 
   require('packer.load')(to_load, {module = module_name}, _G.packer_plugins)

--- a/lua/packer/compile.lua
+++ b/lua/packer/compile.lua
@@ -510,6 +510,6 @@ end
 
 local compile = setmetatable({cfg = cfg}, {__call = make_loaders})
 
-compile.opt_keys = {'after', 'cmd', 'ft', 'keys', 'event', 'cond', 'setup', 'fn'}
+compile.opt_keys = {'after', 'cmd', 'ft', 'keys', 'event', 'cond', 'setup', 'fn', 'module'}
 
 return compile

--- a/lua/packer/compile.lua
+++ b/lua/packer/compile.lua
@@ -46,8 +46,7 @@ local function lazy_load_module(module_name)
   local to_load = {}
   local i = 1
   for module_pat, plugin_name in pairs(module_lazy_loads) do
-    -- check the plugin has not already been loaded to avoid an infinite loop
-    if string.match(module_name, "^" .. module_pat) and not _G.packer_plugins[plugin_name].loaded then
+    if not _G.packer_plugins[plugin_name].loaded and string.match(module_name, "^" .. module_pat) then
       to_load[i] = plugin_name
     end
   end

--- a/lua/packer/compile.lua
+++ b/lua/packer/compile.lua
@@ -40,6 +40,21 @@ local function try_loadstring(s, component, name)
 end
 ]]
 
+local module_loader = [[
+local function lazy_load_module(module_name)
+  if module_name == 'packer.load' then return nil end
+  local to_load = {}
+  local i = 1
+  for module_pat, plugin_name in pairs(module_lazy_loads) do
+    if string.match(module_name, module_pat) then to_load[i] = plugin_name end
+  end
+
+  require('packer.load')(to_load, {module = module_name}, _G.packer_plugins)
+end
+
+table.insert(package.loaders, 1, lazy_load_module)
+]]
+
 local function dump_loaders(loaders)
   local result = vim.deepcopy(loaders)
   for k, _ in pairs(result) do


### PR DESCRIPTION
This PR borrows heavily from dein's implementation of `on_lua` to lazy load a vim package if its lua module is required e.g. 
```lua
-- somewhere in init.lua
use {'akinsho/nvim-bufferline', module = 'bufferline'}
require('bufferline').setup{}
```

#### Todo
- [ ] Should this take a list optionally? why? there's usually just one package name for a lua module and one vim plugin that corresponds to is @wbthomason thoughts?
- [ ] Use `load` function maybe. Currently `packer_load` expects a list of plugins and seems to be designed to load multiple plugins at a time, is it suited to this use case?

Will fix #108