### PR TITLE
Implement User autocmds

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,6 +472,13 @@ The option `compile_on_sync`, which defaults to `true`, will run `packer.compile
 `packer.sync()`, if set to `true`. Note that otherwise, you **must** run `packer.compile` yourself
 to generate the lazy-loader file!
 
+### User autocommands
+`packer` runs most of its operations asyncronously. If you would like to implement automations that
+require knowing when the operations are complete, you can use the following `User` autocmds (see
+`:help User` for more info on how to use):
+
+- `PackerComplete`: Fires after install, update, clean, and sync asynchronous operations finish.
+- `PackerCompileDone`: Fires after compiling (see [the section on compilation](#compiling-lazy-loaders))
 ## Debugging
 `packer.nvim` logs to `stdpath(cache)/packer.nvim.log`. Looking at this file is usually a good start
 if something isn't working as expected.

--- a/doc/packer.txt
+++ b/doc/packer.txt
@@ -394,6 +394,16 @@ They can be configured by changing the value of `config.display.keybindings`
 (see |packer-configuration|). Setting it to `false` will disable all keybindings.
 Setting any of its keys to `false` will disable the corresponding keybinding.
 
+USER AUTOCMDS                                  *packer-user-autocmds*
+`packer` runs most of its operations asyncronously. If you would like to
+implement automations that require knowing when the operations are complete,
+you can use the following User autocmds (see |User| for more info on how to
+use):
+
+`PackerComplete`       Fires after install, update, clean, and sync
+                     asynchronous operations finish.
+`PackerCompiled`       Fires after compiling (see |packer-lazy-load|)
+
 ==============================================================================
 API                                            *packer-api*
 

--- a/doc/packer.txt
+++ b/doc/packer.txt
@@ -402,7 +402,7 @@ use):
 
 `PackerComplete`       Fires after install, update, clean, and sync
                      asynchronous operations finish.
-`PackerCompiled`       Fires after compiling (see |packer-lazy-load|)
+`PackerCompileDone`    Fires after compiling (see |packer-lazy-load|)
 
 ==============================================================================
 API                                            *packer-api*

--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -237,6 +237,7 @@ packer.clean = function(results)
   async(function()
     await(luarocks.clean(rocks, results, nil))
     await(clean(plugins, results))
+    vim.cmd [[doautocmd User PackerComplete]]
   end)()
 end
 
@@ -256,6 +257,7 @@ packer.install = function(...)
 
   if #install_plugins == 0 then
     log.info('All configured plugins are installed')
+    vim.cmd [[doautocmd User PackerComplete]]
     return
   end
 
@@ -281,8 +283,10 @@ packer.install = function(...)
       plugin_utils.update_rplugins()
       local delta = string.gsub(vim.fn.reltimestr(vim.fn.reltime(start_time)), ' ', '')
       display_win:final_results(results, delta)
+      vim.cmd [[doautocmd User PackerComplete]]
     else
       log.info('Nothing to install!')
+      vim.cmd [[doautocmd User PackerComplete]]
     end
   end)()
 end
@@ -329,6 +333,7 @@ packer.update = function(...)
     plugin_utils.update_rplugins()
     local delta = string.gsub(vim.fn.reltimestr(vim.fn.reltime(start_time)), ' ', '')
     display_win:final_results(results, delta)
+    vim.cmd [[doautocmd User PackerComplete]]
   end)()
 end
 
@@ -384,6 +389,7 @@ packer.sync = function(...)
     plugin_utils.update_rplugins()
     local delta = string.gsub(vim.fn.reltimestr(vim.fn.reltime(start_time)), ' ', '')
     display_win:final_results(results, delta)
+    vim.cmd [[doautocmd User PackerComplete]]
   end)()
 end
 
@@ -423,6 +429,7 @@ packer.compile = function(output_path)
   output_file:close()
   if config.auto_reload_compiled then vim.cmd("source " .. output_path) end
   log.info('Finished compiling lazy-loaders!')
+  vim.cmd [[doautocmd User PackerCompiled]]
 end
 
 packer.config = config

--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -436,7 +436,6 @@ packer.compile = function(output_path)
   if config.auto_reload_compiled then vim.cmd("source " .. output_path) end
   log.info('Finished compiling lazy-loaders!')
   packer.on_compile_done()
-  packer.on_complete()
 end
 
 packer.config = config


### PR DESCRIPTION
This feature can enable automations that require knowing when an
asynchronous Packer operation completes. For example, to automatically
sync and quit nvim, you can do something like this:

```viml
function! SyncPluginsAndQuit()
  autocmd User PackerComplete qa
  PackerSync
endfunction
```