### PR TITLE
Add note about usage of packer_plugins table

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,8 @@ print("Vim fugitive is loaded")
 -- other custom logic
 end
 ```
+**NOTE:** this table is only available *after* `packer_compiled.vim` is loaded so cannot be used till *after* plugins
+have been loaded.
 
 #### Luarocks support
 


### PR DESCRIPTION
@wbthomason this PR adds a small note about `packer_plugins` not being available till after `packer_compiled` is loaded since this I think has come up a few times e.g. #262