### PR TITLE
An attempt to resolve lazy loading requirements of plugins

### DIFF
--- a/lua/packer/compile.lua
+++ b/lua/packer/compile.lua
@@ -276,6 +276,11 @@ local function make_loaders(_, plugins)
         end
       end
 
+      if plugin.wants then
+        if type(plugin.wants) == 'string' then plugin.wants = {plugin.wants} end
+        loaders[name].wants = plugin.wants
+      end
+
       if plugin.fn then
         loaders[name].only_sequence = false
         loaders[name].only_setup = false

--- a/lua/packer/load.lua
+++ b/lua/packer/load.lua
@@ -12,6 +12,14 @@ packer_load = function(names, cause, plugins)
     if not plugin.loaded then
       some_unloaded = true
       needs_bufread = needs_bufread or plugin.needs_bufread
+
+      if plugin.wants then
+        for _, wanted_name in ipairs(plugin.wants) do
+          local wanted_plugin = plugins[wanted_name]
+          packer_load({wanted_name}, {}, plugins)
+        end
+      end
+
       if plugin.commands then
         for _, del_cmd in ipairs(plugin.commands) do cmd('silent! delcommand ' .. del_cmd) end
       end


### PR DESCRIPTION
Attempts to close: #250
I have now run multiple times into this issue and it bothers me. While this topic seems to be controversial I decided to give it a try and share my first simple (and working) version here.
Next to the description in the issue, the commit message also includes a kinda generic description of the issue to solve. I settled on the new configuration option name `wants` as a reference to the naming of Systemd service units. So it is not out of nowhere (hopefully many users are already used to it/know its usage) and it also makes sense from the wording to me.
What do you think about the solution? It is pretty simple and flat. I saw some special stuff around (which I have missed since touching the code last time), but it did not look like I need that. Do I miss some important stuff. As I said, for me it is working. See the example `octo.nvim` + `telescope.nvim` and `vim-ultest` + `vim-test`.

---

While I made the attempt to also extend the documentation, I realized that is kinda hard to integrate in combination with the `after` option.  So I think it is required to rephrase this option and the whole **Sequencing** section too.
So I must admit that the `after` option is a little confusing for me. I think there is even an issue for that open? So for me this is actually rather a lazy load kind feature: Load this plugin when the other plugin got loaded. The description/example in the section actually even reads like this where the depending on plugin also is lazy loaded itself.
Could you help?