### PR TITLE
Feature: add packer status

### DIFF
--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -100,6 +100,7 @@ packer.init = function(user_config)
     vim.cmd [[command! PackerSync     lua require('packer').sync()]]
     vim.cmd [[command! PackerClean    lua require('packer').clean()]]
     vim.cmd [[command! PackerCompile  lua require('packer').compile()]]
+    vim.cmd [[command! PackerStatus  lua require('packer').status()]]
   end
 end
 
@@ -396,6 +397,13 @@ packer.sync = function(...)
     local delta = string.gsub(vim.fn.reltimestr(vim.fn.reltime(start_time)), ' ', '')
     display_win:final_results(results, delta)
     packer.on_complete()
+  end)()
+end
+
+packer.status = function ()
+  async(function ()
+    local display_win = display.open(config.display.open_fn or config.display.open_cmd)
+    display_win:status(_G.packer_plugins)
   end)()
 end
 

--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -400,8 +400,8 @@ packer.sync = function(...)
   end)()
 end
 
-packer.status = function ()
-  async(function ()
+packer.status = function()
+  async(function()
     local display_win = display.open(config.display.open_fn or config.display.open_cmd)
     display_win:status(_G.packer_plugins)
   end)()

--- a/lua/packer/display.lua
+++ b/lua/packer/display.lua
@@ -55,19 +55,15 @@ end
 local function format_keys(value)
   local value_type = type(value)
   local mapping = value_type == "string" and value or value[2]
-  local mode = value[1] ~= "" and "mode: "..value[1] or ""
+  local mode = value[1] ~= "" and "mode: " .. value[1] or ""
   local line = fmt('"%s", %s', mapping, mode)
   return line
 end
 
-local function format_cmd(value)
-  return fmt('"%s"', value)
-end
+local function format_cmd(value) return fmt('"%s"', value) end
 
 local function get_key_name(key)
-  if key == "path" then
-    return "opt"
-  end
+  if key == "path" then return "opt" end
   return key
 end
 
@@ -90,18 +86,8 @@ local function format_values(key, value)
 end
 
 local status_keys = {
-  "path",
-  "commands",
-  "keys",
-  "module",
-  "as",
-  "ft",
-  "event",
-  "rocks",
-  "branch",
-  "commit",
-  "tag",
-  "lock",
+  "path", "commands", "keys", "module", "as", "ft", "event", "rocks", "branch", "commit", "tag",
+  "lock"
 }
 
 local config = nil
@@ -281,7 +267,7 @@ local display_mt = {
     for _, c in ipairs(highlights) do vim.cmd(c) end
   end,
 
-  status = vim.schedule_wrap(function (self, plugins)
+  status = vim.schedule_wrap(function(self, plugins)
     if not self:valid_display() then return end
     self:setup_status_syntax()
     self:update_headline_message(fmt("Total plugins: %d", vim.tbl_count(plugins)))
@@ -292,7 +278,7 @@ local display_mt = {
     local padding = string.rep(" ", 3)
     for plug_name, plug_conf in pairs(plugins) do
       local header_lines = {
-        fmt(" • %s ", plug_name)..(not plug_conf.loaded and '(not loaded)' or ''),
+        fmt(" • %s ", plug_name) .. (not plug_conf.loaded and '(not loaded)' or '')
       }
       local config_lines = {}
       for key, value in pairs(plug_conf) do
@@ -602,11 +588,10 @@ local function make_filetype_cmds(working_sym, done_sym, error_sym)
     [[syn match packerPackageNotLoaded /(not loaded)$/]],
     [[syn match packerPackageName /\(^\ • \)\@<=[^ ]*/]],
     [[syn match packerString /\v(''|""|(['"]).{-}[^\\]\2)/]],
-    [[syn match packerBool /\<\(false\|true\)\>/]],
-    'hi def link packerWorking        SpecialKey', 'hi def link packerSuccess        Question',
-    'hi def link packerFail           ErrorMsg', 'hi def link packerHash           Identifier',
-    'hi def link packerRelDate        Comment', 'hi def link packerProgress       Boolean',
-    'hi def link packerOutput         Type'
+    [[syn match packerBool /\<\(false\|true\)\>/]], 'hi def link packerWorking        SpecialKey',
+    'hi def link packerSuccess        Question', 'hi def link packerFail           ErrorMsg',
+    'hi def link packerHash           Identifier', 'hi def link packerRelDate        Comment',
+    'hi def link packerProgress       Boolean', 'hi def link packerOutput         Type'
   }
 end
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/22454918/112768090-28029100-9012-11eb-910b-486c91c2b718.png)



<details>

![packer_status_1](https://user-images.githubusercontent.com/22454918/112676778-c4853180-8e60-11eb-9887-319c1eee7f1f.png)

![packer_status_2](https://user-images.githubusercontent.com/22454918/112676783-c7802200-8e60-11eb-837f-e24553852255.png)

#### Initial attempts
![image](https://user-images.githubusercontent.com/22454918/112553225-014b1d00-8dbc-11eb-891b-c12b78588a47.png)

#### with string highlights
![image](https://user-images.githubusercontent.com/22454918/112554549-6c95ee80-8dbe-11eb-8cc3-be8565aa01d4.png)
</details>



This PR will provide a new `PackerStatus` function which will open a window listing the currently installed packer plugins and their loaded status. I plan to start minimally by just adding the window with some basic info in this PR but hopefully I can iterate on this window so users can see the most recent commits as well as carry out actions like delete,revert etc. through the UI

This PR will fix #12

#### Follow up PR
- view latest update
- ability to revert
- ability to delete
- ability to load
