### PR TITLE
Compile cmd as silent commands

### DIFF
--- a/lua/packer/compile.lua
+++ b/lua/packer/compile.lua
@@ -365,7 +365,7 @@ local function make_loaders(_, plugins)
   local command_defs = {}
   for command, names in pairs(commands) do
     local command_line = fmt(
-                           'vim.cmd [[command! -nargs=* -range -bang -complete=file %s lua require("packer.load")({%s}, { cmd = "%s", l1 = <line1>, l2 = <line2>, bang = <q-bang>, args = <q-args> }, _G.packer_plugins)]]',
+                           'vim.cmd [[silent! command -nargs=* -range -bang -complete=file %s lua require("packer.load")({%s}, { cmd = "%s", l1 = <line1>, l2 = <line2>, bang = <q-bang>, args = <q-args> }, _G.packer_plugins)]]',
                            command, table.concat(names, ', '), command)
     table.insert(command_defs, command_line)
   end


### PR DESCRIPTION
This pr will compile cmd as silent commands which could bypass the `Invalid command name` error:
```
Error in packer_compiled: Vim(lua):E5108: Error executing lua [string ":lua"]:373: Vim(command):E182: Invalid command name
```