### PR TITLE
Fix incorrect rtp directory concatenation

### DIFF
--- a/lua/packer/compile.lua
+++ b/lua/packer/compile.lua
@@ -163,12 +163,16 @@ local function make_loaders(_, plugins)
         end
       end
 
-      if plugin.rtp then table.insert(rtps, util.join_paths(plugin.install_path, plugin.rtp)) end
+      local path = plugin.install_path
+      if plugin.rtp then
+        path = util.join_paths(plugin.install_path, plugin.rtp)
+        table.insert(rtps, path)
+      end
 
       loaders[name] = {
         loaded = not plugin.opt,
         config = plugin.config,
-        path = plugin.install_path .. (plugin.rtp and plugin.rtp or ''),
+        path = path,
         only_sequence = plugin.manual_opt == nil,
         only_setup = false
       }

--- a/lua/packer/util.lua
+++ b/lua/packer/util.lua
@@ -122,12 +122,12 @@ util.float = function()
   local buf = vim.api.nvim_create_buf(false, true)
   local win = vim.api.nvim_open_win(buf, true, opts)
 
-  function restore_cursor()
+  function _G.__packer_restore_cursor()
     vim.api.nvim_set_current_win(last_win)
     vim.api.nvim_win_set_cursor(last_win, last_pos)
   end
 
-  vim.cmd('autocmd! BufWipeout <buffer> lua restore_cursor()')
+  vim.cmd('autocmd! BufWipeout <buffer> lua __packer_restore_cursor()')
 
   return true, win, buf
 end


### PR DESCRIPTION
This PR fixes an issue where the plugin's install path was being directly concatenated with the `rtp` path rather than joining the two with a path separator as is being done for the actual `&rtp`.

Note for some reason the plugin that was mentioned in #274, `himalaya` still does not appear to load so it's not clear if this is an issue with that plugin or with packer.

Also note (unrelated fix): I took the liberty of fixing a global function I noticed with a very generic name that felt highly likely to eventually cause a clash with some user defined functionality. `restore_cursor`, I think going forward all global callbacks should probably be name spaced under an object like `__packer.callback` to reduce the likely hood of clashes

Fixes #274 