### PR TITLE
Fix #273: Escape any backslashes in event pattern strings

### DIFF
--- a/lua/packer/compile.lua
+++ b/lua/packer/compile.lua
@@ -320,7 +320,7 @@ local function make_loaders(_, plugins)
   for event, names in pairs(events) do
     table.insert(event_aucmds, fmt(
                    'vim.cmd [[au %s ++once lua require("packer.load")({%s}, { event = "%s" }, _G.packer_plugins)]]',
-                   event, table.concat(names, ', '), event))
+                   event, table.concat(names, ', '), event:gsub([[\]], [[\\]])))
   end
 
   local config_lines = {}


### PR DESCRIPTION
Attempts to fix #273 by escaping backslashes in event patterns. I'm not 100% convinced that this simple fix won't break something with patterns, e.g. by escaping already-escaped backslashes, but I haven't put together a counterexample yet.