### PR TITLE
Fix lazy loading plugins via require

### DIFF
--- a/lua/packer/compile.lua
+++ b/lua/packer/compile.lua
@@ -42,10 +42,6 @@ end
 
 local module_loader = [[
 
-local function escape_pattern(text)
-    return text:gsub("([^%w])", "%%%1")
-end
-
 local lazy_load_called = {}
 local to_load = {}
 
@@ -53,7 +49,7 @@ local function lazy_load_module(module_name)
   if module_name == 'packer.load' or lazy_load_called[module_name] then return nil end
   lazy_load_called[module_name] = true
   for module_pat, plugin_name in pairs(module_lazy_loads) do
-    if not _G.packer_plugins[plugin_name].loaded and string.match(module_name, "^" .. escape_pattern(module_pat)) then
+    if not _G.packer_plugins[plugin_name].loaded and string.match(module_name, "^" .. vim.pesc(module_pat)) then
       to_load[#to_load + 1] = plugin_name
     end
   end

--- a/lua/packer/compile.lua
+++ b/lua/packer/compile.lua
@@ -41,11 +41,9 @@ end
 ]]
 
 local module_loader = [[
-
 local lazy_load_called = {}
-local to_load = {}
-
 local function lazy_load_module(module_name)
+  local to_load = {}
   if module_name == 'packer.load' or lazy_load_called[module_name] then return nil end
   lazy_load_called[module_name] = true
   for module_pat, plugin_name in pairs(module_lazy_loads) do

--- a/lua/packer/compile.lua
+++ b/lua/packer/compile.lua
@@ -41,13 +41,20 @@ end
 ]]
 
 local module_loader = [[
+
+local function escape_pattern(text)
+    return text:gsub("([^%w])", "%%%1")
+end
+
+local lazy_load_called = {}
+local to_load = {}
+
 local function lazy_load_module(module_name)
-  if module_name == 'packer.load' then return nil end
-  local to_load = {}
-  local i = 1
+  if module_name == 'packer.load' or lazy_load_called[module_name] then return nil end
+  lazy_load_called[module_name] = true
   for module_pat, plugin_name in pairs(module_lazy_loads) do
-    if not _G.packer_plugins[plugin_name].loaded and string.match(module_name, "^" .. module_pat) then
-      to_load[i] = plugin_name
+    if not _G.packer_plugins[plugin_name].loaded and string.match(module_name, "^" .. escape_pattern(module_pat)) then
+      to_load[#to_load + 1] = plugin_name
     end
   end
 
@@ -55,7 +62,7 @@ local function lazy_load_module(module_name)
 end
 
 if not vim.g.packer_custom_loader_enabled then
-  table.insert(package.loaders, 2, lazy_load_module)
+  table.insert(package.loaders, 1, lazy_load_module)
   vim.g.packer_custom_loader_enabled = true
 end
 ]]


### PR DESCRIPTION
This PR builds on #248 which at present doesn't actually work for a few reasons.

1. The name of the module passed in is not escaped and can contain special characters for lua patterns such as `-`, `.` etc. so the match actually fails in most cases.
2. With the names escaped packages are still not lazy loaded immediately because our loader is second in the list and seems the first loader failing will end up throwing an error.
3. With our loader as first in the list you get an infinite loop error because `require('lazy-load')` will go on cause a bunch of other requires so we need to cache what we have already checked.

@wbthomason this implementation is much closer to [`dein`'s](https://github.com/Shougo/dein.vim/commit/c6ddf04183606413870a0f8a86f61f8d58f85982) which I now believe was the way it is for the reasons above and so ours needs to match that.

Things I think will be of note:
1. Making the custom loader first in the order. I thought this might be a point of contention so I tested several times if it was possible to move it to 2 and have this work. Unfortunately it isn't. The first loader not finding our module seems to result in an error the first time. So with the loader as second the flow is `trigger lazy load via mapping -> errors first time -> trigger mapping -> success`. Whereas with the loader as first it works straight away.

2. Add the table of all previously checked modules. `dein` does a similar thing which I was wary of leaving out the first time around since I encountered some infinite loops initially. The reason we weren't seeing this was that the first loader handles keeping track of what was called. Since this loader is now first it needs to check so that subsequent calls to lazy load module don't try and check all modules infinitely.

I'm a little fuzzy on some aspects of how this works and fails primarily around the infinite looping and the exact behaviour of the first loader. Though I'm pretty sure that this now works.