### PR TITLE
docs: Use `system()` in the bootstrapping snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ local fn = vim.fn
 local install_path = fn.stdpath('data')..'/site/pack/packer/opt/packer.nvim'
 
 if fn.empty(fn.glob(install_path)) > 0 then
-  execute('!git clone https://github.com/wbthomason/packer.nvim '..install_path)
+  fn.system({'git', 'clone', 'https://github.com/wbthomason/packer.nvim', install_path})
   execute 'packadd packer.nvim'
 end
 ```


### PR DESCRIPTION
Passing a List to `system()` saves users the trouble of escaping spaces and other problematic characters

(You can test this with `:call system(['git', 'clone', 'https://github.com/wbthomason/packer.nvim', 'my folder with spaces'])`)

Partially addresses #287