### PR TITLE
Fix possible lazy loading recursion when running plugin config

### DIFF
--- a/lua/packer/load.lua
+++ b/lua/packer/load.lua
@@ -35,10 +35,14 @@ packer_load = function(names, cause, plugins)
         end
       end
 
+      -- set plugin as loaded before config is run in case something in the config
+      -- tries to load this same plugin again
+      plugin.loaded = true
       if plugin.config then
         for _, config_line in ipairs(plugin.config) do
           local success, err = pcall(loadstring(config_line))
           if not success then
+            plugin.loaded = false
             print('Error running config for ' .. names[i])
             error(err)
           end
@@ -54,8 +58,6 @@ packer_load = function(names, cause, plugins)
           end
         end
       end
-
-      plugins[names[i]].loaded = true
     end
   end
 


### PR DESCRIPTION
I ran into this problem when lazy loading on require. If the config for a plugin required a module which was set to lazy load that same plugin, recursion would occur because the plugin has not been set to loaded before running the config.

I originally changed `lazy_load_module()` in compile.lua which fixed it specifically for lazy loading on require however I then thought it might be simpler to just set the plugin as loaded before config is run inside the main load function. This way it will also fix this in case there is any other way to load a plugin inside it's own config.