### PR TITLE
Fix first half of #299: Correct module load ordering

### DIFF
--- a/lua/packer/compile.lua
+++ b/lua/packer/compile.lua
@@ -47,7 +47,7 @@ local function lazy_load_module(module_name)
   if lazy_load_called[module_name] then return nil end
   lazy_load_called[module_name] = true
   for module_pat, plugin_name in pairs(module_lazy_loads) do
-    if not _G.packer_plugins[plugin_name].loaded and string.match(module_name, "^" .. vim.pesc(module_pat)) then
+    if not _G.packer_plugins[plugin_name].loaded and string.match(module_name, module_pat)then
       to_load[#to_load + 1] = plugin_name
     end
   end
@@ -300,7 +300,9 @@ local function make_loaders(_, plugins)
         loaders[name].only_sequence = false
         loaders[name].only_setup = false
         if type(plugin.module) == 'string' then plugin.module = {plugin.module} end
-        for _, module_name in ipairs(plugin.module) do module_lazy_loads[module_name] = name end
+        for _, module_name in ipairs(plugin.module) do
+          module_lazy_loads['^' .. vim.pesc(module_name)] = name
+        end
       end
 
       if plugin.config and (not plugin.opt or loaders[name].only_setup) then

--- a/lua/packer/compile.lua
+++ b/lua/packer/compile.lua
@@ -41,10 +41,10 @@ end
 ]]
 
 local module_loader = [[
-local lazy_load_called = {}
+local lazy_load_called = {['packer.load'] = true}
 local function lazy_load_module(module_name)
   local to_load = {}
-  if module_name == 'packer.load' or lazy_load_called[module_name] then return nil end
+  if lazy_load_called[module_name] then return nil end
   lazy_load_called[module_name] = true
   for module_pat, plugin_name in pairs(module_lazy_loads) do
     if not _G.packer_plugins[plugin_name].loaded and string.match(module_name, "^" .. vim.pesc(module_pat)) then

--- a/lua/packer/load.lua
+++ b/lua/packer/load.lua
@@ -10,6 +10,7 @@ packer_load = function(names, cause, plugins)
   for i = 1, num_names do
     local plugin = plugins[names[i]]
     if not plugin.loaded then
+      plugin.loaded = true
       some_unloaded = true
       needs_bufread = needs_bufread or plugin.needs_bufread
 
@@ -54,8 +55,6 @@ packer_load = function(names, cause, plugins)
           end
         end
       end
-
-      plugins[names[i]].loaded = true
     end
   end
 

--- a/lua/packer/load.lua
+++ b/lua/packer/load.lua
@@ -8,6 +8,8 @@ packer_load = function(names, cause, plugins)
   for i = 1, num_names do
     local plugin = plugins[names[i]]
     if not plugin.loaded then
+      -- Set the plugin as loaded before config is run in case something in the config tries to load
+      -- this same plugin again
       plugin.loaded = true
       some_unloaded = true
       needs_bufread = needs_bufread or plugin.needs_bufread

--- a/lua/packer/load.lua
+++ b/lua/packer/load.lua
@@ -1,10 +1,8 @@
 local packer_load = nil
-
 packer_load = function(names, cause, plugins)
   local some_unloaded = false
   local needs_bufread = false
   local num_names = #names
-
   local cmd = vim.api.nvim_command
   local fmt = string.format
   for i = 1, num_names do
@@ -13,7 +11,6 @@ packer_load = function(names, cause, plugins)
       plugin.loaded = true
       some_unloaded = true
       needs_bufread = needs_bufread or plugin.needs_bufread
-
       if plugin.wants then
         for _, wanted_name in ipairs(plugin.wants) do packer_load({wanted_name}, {}, plugins) end
       end
@@ -26,7 +23,7 @@ packer_load = function(names, cause, plugins)
         for _, key in ipairs(plugin.keys) do cmd(fmt('silent! %sunmap %s', key[1], key[2])) end
       end
 
-      vim.cmd('packadd ' .. names[i])
+      cmd('packadd ' .. names[i])
       if plugin.after_files then
         for _, file in ipairs(plugin.after_files) do
           cmd('silent exe "source ' .. file .. '"')

--- a/lua/packer/load.lua
+++ b/lua/packer/load.lua
@@ -15,10 +15,7 @@ packer_load = function(names, cause, plugins)
       needs_bufread = needs_bufread or plugin.needs_bufread
 
       if plugin.wants then
-        for _, wanted_name in ipairs(plugin.wants) do
-          local wanted_plugin = plugins[wanted_name]
-          packer_load({wanted_name}, {}, plugins)
-        end
+        for _, wanted_name in ipairs(plugin.wants) do packer_load({wanted_name}, {}, plugins) end
       end
 
       if plugin.commands then


### PR DESCRIPTION
Previously, we set a plugin as `loaded = true` at the *end* of its part of the load function. However, with the addition of Lua module lazy-loading, the load function is re-entrant. This means that we try to load a plugin in the middle of loading it, which breaks all sorts of things.

These changes move the `loaded = true` mark earlier to prevent this, and include miscellaneous fixes and refactorings for the module lazy-loader.

This does **not** fix the part of #299 that arises from transitive optness with `require`'d plugins; that's a duplicate of #87 and will be fixed in another PR (hopefully in the next few days, if I can get to it).

@shadmansaleh, can you please confirm that this solves #299 for you if you ensure that `plenary` and `popup` are not `opt` first (or wait until the second PR to fix that part too)?