### PR TITLE
Feature/add testing infrastructure

### DIFF
--- a/lua/packer/.github/workflows/test.yaml
+++ b/lua/packer/.github/workflows/test.yaml
@@ -1,0 +1,31 @@
+---
+name: Run tests
+on:
+  pull_request: ~
+  push:
+    branches:
+      - master
+
+    jobs:
+      build:
+        name: Run tests
+        runs-on: ubuntu-latest
+
+        steps:
+          - uses: actions/checkout@v2
+          - run: date +%F > todays-date
+          - name: Restore cache for today's nightly.
+            uses: actions/cache@v2
+            with:
+              path: _neovim
+              key: ${{ runner.os }}-x64-${{ hashFiles('todays-date') }}
+
+          - name: Prepare plenary
+            run: |
+              git clone --depth 1 https://github.com/nvim-lua/plenary.nvim ~/.local/share/nvim/site/pack/vendor/start/plenary.nvim
+              ln -s $(pwd) ~/.local/share/nvim/site/pack/vendor/start
+          - name: Run tests
+            run: |
+              curl -OL https://raw.githubusercontent.com/norcalli/bot-ci/master/scripts/github-actions-setup.sh
+              source github-actions-setup.sh nightly-x64
+              nvim --headless --noplugin -u tests/minimal.vim -c "PlenaryBustedDirectory tests/ {minimal_init = 'tests/minimal.vim'}"

--- a/lua/packer/tests/minimal.vim
+++ b/lua/packer/tests/minimal.vim
@@ -1,0 +1,3 @@
+set rtp+=.
+set rtp+=../plenary.nvim
+runtime! plugin/plenary.vim

--- a/lua/packer/tests/packer_use_spec.lua
+++ b/lua/packer/tests/packer_use_spec.lua
@@ -1,0 +1,23 @@
+local packer = require("packer")
+local use = packer.use
+local packer_path = vim.fn.stdpath("data").."/site/pack/packer/start/"
+
+describe("Packer use tests", function()
+  after_each(function()
+    packer.reset()
+  end)
+
+  it("should set the correct install path", function ()
+    local spec = {"test/plugin1"}
+    use(spec)
+    assert.truthy(spec.install_path)
+    assert.equal(spec.install_path, packer_path ..spec.short_name)
+  end)
+
+  it("should add metadata to a plugin from a spec", function ()
+    local spec = {"test/plugin1"}
+    use(spec)
+    assert.equal(spec.name, "test/plugin1")
+    assert.equal(spec.path, "test/plugin1")
+  end)
+end)


### PR DESCRIPTION
@wbthomason should probably have run this past you in an issue but it's pretty simple to setup so I just did it.

This PR adds the infrastructure required to run tests for packer using `plenary`'s busted test lib. It doesn't require users to have plenary just CI and anyone developing locally. If this seems alright to you I'll add a contributing section that describes how to run tests locally.

The tests currently in place are more examples/placeholders and something to run for now