### PR TITLE
chore: add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,21 @@
+---
+name: Bug report
+about: Report a bug in packer.nvim
+labels: bug
+
+---
+
+<!-- Before creating an issue, please search the issue tracker and make sure packer.nvim is up to date -->
+<!-- If your issue is a general usage question, please create a GitHub discussions thread: https://github.com/wbthomason/packer.nvim/discussions -->
+
+- `nvim --version`:
+- `git --version`:
+- Operating system/version:
+- Terminal name/version:
+
+### Steps to reproduce
+
+### Actual behaviour
+
+### Expected behaviour
+

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -19,3 +19,14 @@ labels: bug
 
 ### Expected behaviour
 
+### packer files
+
+<details>
+<summary>packer log file</summary>
+Post the contents of ~/.cache/nvim/packer.nvim.log here
+</details>
+
+<details>
+<summary>packer compiled file</summary>
+Post the contents of `packer_compiled.vim` here
+</details>

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,12 @@
+---
+name: Feature request
+about: Suggest a feature for packer.nvim
+labels: enhancement
+
+---
+
+<!-- Before creating an issue, please search the issue tracker and make sure packer.nvim is up to date -->
+<!-- If your issue is a general usage question, please create a GitHub discussions thread: https://github.com/wbthomason/packer.nvim/discussions -->
+
+### Describe the feature
+


### PR DESCRIPTION
This PR adds issue templates (largely inspired by the ones in the Neovim repository).

Hopefully encouraging users to answer these questions upfront will reduce the amount of back and forth needed to diagnose issues since a lot of them tend to be related to software/os versions