### PR TITLE
docs: Add diff keybinding

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ default configuration values (and structure of the configuration table) are:
     keybindings = { -- Keybindings for the display window
       quit = 'q',
       toggle_info = '<CR>',
+      diff = 'd',
       prompt_revert = 'r',
     }
   },

--- a/doc/packer.txt
+++ b/doc/packer.txt
@@ -223,6 +223,7 @@ default values: >
       keybindings = { -- Keybindings for the display window
         quit = 'q',
         toggle_info = '<CR>',
+        diff = 'd',
         prompt_revert = 'r',
       }
     }


### PR DESCRIPTION
I noticed that the `diff` keybinding isn't listed in the README and vimdoc so I added it