### PR TITLE
compile.lua: better error messages when nil

### DIFF
--- a/lua/packer/compile.lua
+++ b/lua/packer/compile.lua
@@ -480,6 +480,9 @@ local function make_loaders(_, plugins, should_profile)
 
   local sequence_loads = {}
   for pre, posts in pairs(after) do
+    if plugins[pre] == nil then
+     error(string.format("Compile.lua dependency not loaded %s %s", pre, vim.inspect(posts))) 
+    end
     if plugins[pre].opt then
       loaders[pre].after = posts
     elseif plugins[pre].only_config then

--- a/lua/packer/compile.lua
+++ b/lua/packer/compile.lua
@@ -481,8 +481,9 @@ local function make_loaders(_, plugins, should_profile)
   local sequence_loads = {}
   for pre, posts in pairs(after) do
     if plugins[pre] == nil then
-     error(string.format("Compile.lua dependency not loaded %s %s", pre, vim.inspect(posts))) 
+      error(string.format('Dependency %s for %s not found', pre, vim.inspect(posts)))
     end
+
     if plugins[pre].opt then
       loaders[pre].after = posts
     elseif plugins[pre].only_config then


### PR DESCRIPTION
It is an issue for me from time to time when I update vimrc and failed to compile. Sometimes the error message is obvious and sometimes not.
This PR is to address the case when dependency(after) was not setup up correctly and compile.lua failed of nil dereference. 