### PR TITLE
feat: add ability to detect when a different repo with a similar name is added

### DIFF
--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -266,9 +266,7 @@ local function args_or_all(...) return util.nonempty_or({...}, vim.tbl_keys(plug
 -- Installs missing plugins, then updates helptags and rplugins
 packer.install = function(...)
   local install_plugins
-  if ... then
-    install_plugins = {...}
-  end
+  if ... then install_plugins = {...} end
   async(function()
     if not install_plugins then
       install_plugins = await(plugin_utils.find_missing_plugins(plugins))

--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -268,17 +268,18 @@ packer.install = function(...)
   local install_plugins
   if ... then
     install_plugins = {...}
-  else
-    install_plugins = plugin_utils.find_missing_plugins(plugins)
   end
-
-  if #install_plugins == 0 then
-    log.info('All configured plugins are installed')
-    packer.on_complete()
-    return
-  end
-
   async(function()
+    if not install_plugins then
+      install_plugins = await(plugin_utils.find_missing_plugins(plugins))
+    end
+
+    if #install_plugins == 0 then
+      log.info('All configured plugins are installed')
+      packer.on_complete()
+      return
+    end
+
     local start_time = vim.fn.reltime()
     local results = {}
     await(clean(plugins, results))
@@ -320,9 +321,8 @@ packer.update = function(...)
     local start_time = vim.fn.reltime()
     local results = {}
     await(clean(plugins, results))
-    local missing_plugins, installed_plugins = util.partition(
-                                                 plugin_utils.find_missing_plugins(plugins),
-                                                 update_plugins)
+    local missing = await(plugin_utils.find_missing_plugins(plugins))
+    local missing_plugins, installed_plugins = util.partition(missing, update_plugins)
 
     update.fix_plugin_types(plugins, missing_plugins, results)
     local _
@@ -369,9 +369,8 @@ packer.sync = function(...)
   async(function()
     local start_time = vim.fn.reltime()
     local results = {}
-    local missing_plugins, installed_plugins = util.partition(
-                                                 plugin_utils.find_missing_plugins(plugins),
-                                                 sync_plugins)
+    local r = await(plugin_utils.find_missing_plugins(plugins))
+    local missing_plugins, installed_plugins = util.partition(r or {}, sync_plugins)
 
     update.fix_plugin_types(plugins, missing_plugins, results)
     local _

--- a/lua/packer/clean.lua
+++ b/lua/packer/clean.lua
@@ -25,7 +25,7 @@ local clean_plugins = function(_, plugins, results)
     results.removals = results.removals or {}
     await(a.main)
     local opt_plugins, start_plugins = plugin_utils.list_installed_plugins()
-    local missing_plugins = plugin_utils.find_missing_plugins(plugins, opt_plugins, start_plugins)
+    local missing_plugins = await(plugin_utils.find_missing_plugins(plugins))
     -- turn the list into a hashset-like structure
     for idx, plugin_name in ipairs(missing_plugins) do
       missing_plugins[plugin_name] = true

--- a/lua/packer/plugin_types/git.lua
+++ b/lua/packer/plugin_types/git.lua
@@ -173,6 +173,15 @@ git.setup = function(plugin)
     end)
   end
 
+  plugin.remote_url = function ()
+    return async(function ()
+      return await(jobs.run(fmt("%s remote get-url origin", config.exec_cmd),
+      {capture_output = true, cwd = plugin.install_path })):map_ok(function (data)
+        return { remote = data.output.data.stdout[1] }
+      end)
+    end)
+  end
+
   plugin.updater = function(disp)
     return async(function()
       local update_info = {err = {}, revs = {}, output = {}, messages = {}}

--- a/lua/packer/plugin_types/git.lua
+++ b/lua/packer/plugin_types/git.lua
@@ -38,8 +38,8 @@ local handle_checkouts = function(plugin, dest, disp)
         disp:task_update(plugin_name, fmt('checking out %s %s...',
                                           plugin.branch and 'branch' or 'tag', branch_or_tag))
       end
-      r:and_then(await, jobs.run(config.exec_cmd
-                                   .. fmt(config.subcommands.checkout, dest, branch_or_tag), opts))
+      r:and_then(await, jobs.run(
+                   config.exec_cmd .. fmt(config.subcommands.checkout, dest, branch_or_tag), opts))
         :map_err(function(err)
           return {
             msg = fmt('Error checking out %s %s for %s', plugin.branch and 'branch' or 'tag',
@@ -54,8 +54,8 @@ local handle_checkouts = function(plugin, dest, disp)
       if disp ~= nil then
         disp:task_update(plugin_name, fmt('checking out %s...', plugin.commit))
       end
-      r:and_then(await, jobs.run(config.exec_cmd
-                                   .. fmt(config.subcommands.checkout, dest, plugin.commit), opts))
+      r:and_then(await, jobs.run(
+                   config.exec_cmd .. fmt(config.subcommands.checkout, dest, plugin.commit), opts))
         :map_err(function(err)
           return {
             msg = fmt('Error checking out commit %s for %s', plugin.commit, plugin_name),
@@ -65,19 +65,18 @@ local handle_checkouts = function(plugin, dest, disp)
         end)
     end
 
-    return r:map_ok(function(ok) return {status = ok, output = output} end):map_err(
-             function(err)
-        if not err.msg then
-          return {
-            msg = fmt('Error updating %s: %s', plugin_name, table.concat(err, '\n')),
-            data = err,
-            output = output
-          }
-        end
+    return r:map_ok(function(ok) return {status = ok, output = output} end):map_err(function(err)
+      if not err.msg then
+        return {
+          msg = fmt('Error updating %s: %s', plugin_name, table.concat(err, '\n')),
+          data = err,
+          output = output
+        }
+      end
 
-        err.output = output
-        return err
-      end)
+      err.output = output
+      return err
+    end)
   end)
 end
 
@@ -145,40 +144,37 @@ git.setup = function(plugin)
       if plugin.commit then
         disp:task_update(plugin_name, fmt('checking out %s...', plugin.commit))
         r:and_then(await,
-                   jobs.run(config.exec_cmd
-                              .. fmt(config.subcommands.checkout, install_to, plugin.commit),
-                            installer_opts)):map_err(
-          function(err)
-            return {
-              msg = fmt('Error checking out commit %s for %s', plugin.commit, plugin_name),
-              data = {err, output}
-            }
-          end)
+                   jobs.run(
+                     config.exec_cmd .. fmt(config.subcommands.checkout, install_to, plugin.commit),
+                     installer_opts)):map_err(function(err)
+          return {
+            msg = fmt('Error checking out commit %s for %s', plugin.commit, plugin_name),
+            data = {err, output}
+          }
+        end)
       end
 
-      r:and_then(await, jobs.run(commit_cmd, installer_opts)):map_ok(
-        function(_) plugin.messages = output.data.stdout end):map_err(
-        function(err)
-          plugin.output = {err = output.data.stderr}
-          if not err.msg then
-            return {
-              msg = fmt('Error installing %s: %s', plugin_name,
-                        table.concat(output.data.stderr, '\n')),
-              data = {err, output}
-            }
-          end
-        end)
+      r:and_then(await, jobs.run(commit_cmd, installer_opts)):map_ok(function(_)
+        plugin.messages = output.data.stdout
+      end):map_err(function(err)
+        plugin.output = {err = output.data.stderr}
+        if not err.msg then
+          return {
+            msg = fmt('Error installing %s: %s', plugin_name, table.concat(output.data.stderr, '\n')),
+            data = {err, output}
+          }
+        end
+      end)
 
       return r
     end)
   end
 
-  plugin.remote_url = function ()
-    return async(function ()
+  plugin.remote_url = function()
+    return async(function()
       return await(jobs.run(fmt("%s remote get-url origin", config.exec_cmd),
-      {capture_output = true, cwd = plugin.install_path })):map_ok(function (data)
-        return { remote = data.output.data.stdout[1] }
-      end)
+                            {capture_output = true, cwd = plugin.install_path})):map_ok(function(
+        data) return {remote = data.output.data.stdout[1]} end)
     end)
   end
 
@@ -208,16 +204,15 @@ git.setup = function(plugin)
       local current_branch
       disp:task_update(plugin_name, 'checking current branch...')
       r:and_then(await, jobs.run(branch_cmd, {success_test = exit_ok, capture_output = true}))
-        :map_ok(function(ok) current_branch = ok.output.data.stdout[1] end):map_err(
-          function(err)
-            plugin.output = {err = vim.list_extend(update_info.err, update_info.revs), data = {}}
+        :map_ok(function(ok) current_branch = ok.output.data.stdout[1] end):map_err(function(err)
+          plugin.output = {err = vim.list_extend(update_info.err, update_info.revs), data = {}}
 
-            return {
-              msg = fmt('Error checking current branch for %s: %s', plugin_name,
-                        table.concat(update_info.revs, '\n')),
-              data = err
-            }
-          end)
+          return {
+            msg = fmt('Error checking current branch for %s: %s', plugin_name,
+                      table.concat(update_info.revs, '\n')),
+            data = err
+          }
+        end)
 
       if not needs_checkout then
         local origin_branch = ''
@@ -324,9 +319,9 @@ git.setup = function(plugin)
       local diff_info = {err = {}, output = {}, messages = {}}
       local diff_onread = jobs.logging_callback(diff_info.err, diff_info.messages)
       local diff_callbacks = {stdout = diff_onread, stderr = diff_onread}
-      return await(jobs.run(diff_cmd, {capture_output = diff_callbacks})):map_ok(
-               function(_) return callback(diff_info.messages) end):map_err(
-               function(err) return callback(nil, err) end)
+      return await(jobs.run(diff_cmd, {capture_output = diff_callbacks})):map_ok(function(_)
+        return callback(diff_info.messages)
+      end):map_err(function(err) return callback(nil, err) end)
     end)()
   end
 

--- a/lua/packer/plugin_utils.lua
+++ b/lua/packer/plugin_utils.lua
@@ -124,8 +124,14 @@ plugin_utils.find_missing_plugins = function(plugins, opt_plugins, start_plugins
         local r = await(plugin.remote_url())
         local remote = r.ok and r.ok.remote or nil
         if remote then
-          local parts = vim.split(remote, "/")
-          local repo_name = util.join_paths(unpack(vim.list_slice(parts, #parts - 1, #parts)))
+          local repo_name
+          if remote:match('git@github.com') then
+            local parts = vim.split(remote, ":")
+            repo_name = parts[#parts]
+          else
+            local parts = vim.split(remote, "/")
+            repo_name = util.join_paths(unpack(vim.list_slice(parts, #parts - 1, #parts)))
+          end
           repo_name = repo_name:gsub("%.git", "")
           if repo_name and repo_name ~= plugin.name then
             table.insert(missing_plugins, plugin_name)

--- a/lua/packer/plugin_utils.lua
+++ b/lua/packer/plugin_utils.lua
@@ -88,9 +88,7 @@ plugin_utils.update_helptags = vim.schedule_wrap(function(...)
 end)
 
 plugin_utils.update_rplugins = vim.schedule_wrap(function()
-  if vim.fn.exists(':UpdateRemotePlugins') == 2 then
-    vim.cmd [[silent UpdateRemotePlugins]]
-  end
+  if vim.fn.exists(':UpdateRemotePlugins') == 2 then vim.cmd [[silent UpdateRemotePlugins]] end
 end)
 
 plugin_utils.ensure_dirs = function()
@@ -100,7 +98,7 @@ plugin_utils.ensure_dirs = function()
 end
 
 plugin_utils.find_missing_plugins = function(plugins, opt_plugins, start_plugins)
-  return a.sync(function ()
+  return a.sync(function()
     if opt_plugins == nil or start_plugins == nil then
       opt_plugins, start_plugins = plugin_utils.list_installed_plugins()
     end
@@ -112,7 +110,7 @@ plugin_utils.find_missing_plugins = function(plugins, opt_plugins, start_plugins
       local plugin = plugins[plugin_name]
 
       local plugin_path = util.join_paths(config[plugin.opt and 'opt_dir' or 'start_dir'],
-      plugin.short_name)
+                                          plugin.short_name)
       local plugin_installed = (plugin.opt and opt_plugins or start_plugins)[plugin_path]
 
       await(a.main)
@@ -198,14 +196,15 @@ plugin_utils.post_update_hook = function(plugin, disp)
                                            plugin_name)
           }
           local cmd = {os.getenv('SHELL') or vim.o.shell, '-c', plugin.run}
-          return await(jobs.run(cmd, {capture_output = hook_callbacks, cwd = plugin.install_path})):map_err(
-                   function(err)
-              return {
-                msg = string.format('Error running post update hook: %s',
-                                    table.concat(hook_output.output, '\n')),
-                data = err
-              }
-            end)
+          return
+            await(jobs.run(cmd, {capture_output = hook_callbacks, cwd = plugin.install_path})):map_err(
+              function(err)
+                return {
+                  msg = string.format('Error running post update hook: %s',
+                                      table.concat(hook_output.output, '\n')),
+                  data = err
+                }
+              end)
         end
       else
         -- TODO/NOTE: This case should also capture output in case of error. The minor difficulty is

--- a/tests/helpers.lua
+++ b/tests/helpers.lua
@@ -1,8 +1,6 @@
 local util = require("packer.util")
 
-local M = {
-  base_dir = "/tmp/__packer_tests__"
-}
+local M = {base_dir = "/tmp/__packer_tests__"}
 
 ---Create a fake git repository
 ---@param name string
@@ -17,10 +15,6 @@ end
 
 ---Remove directories created for test purposes
 ---@vararg string
-function M.cleanup_dirs(...)
-  for _,dir in ipairs({...}) do
-    vim.fn.delete(dir, "rf")
-  end
-end
+function M.cleanup_dirs(...) for _, dir in ipairs({...}) do vim.fn.delete(dir, "rf") end end
 
 return M

--- a/tests/helpers.lua
+++ b/tests/helpers.lua
@@ -1,0 +1,26 @@
+local util = require("packer.util")
+
+local M = {
+  base_dir = "/tmp/__packer_tests__"
+}
+
+---Create a fake git repository
+---@param name string
+---@param base string
+function M.create_git_dir(name, base)
+  base = base or M.base_dir
+  local repo_path = util.join_paths(base, name)
+  local path = util.join_paths(repo_path, ".git")
+  vim.fn.mkdir(path, "p")
+  return repo_path
+end
+
+---Remove directories created for test purposes
+---@vararg string
+function M.cleanup_dirs(...)
+  for _,dir in ipairs({...}) do
+    vim.fn.delete(dir, "rf")
+  end
+end
+
+return M

--- a/tests/packer_plugin_utils_spec.lua
+++ b/tests/packer_plugin_utils_spec.lua
@@ -1,25 +1,21 @@
 local a = require('plenary.async_lib.tests')
 local await = require('packer.async').wait
 local plugin_utils = require("packer.plugin_utils")
-local packer_path = vim.fn.stdpath("data").."/site/pack/packer/start/"
+local packer_path = vim.fn.stdpath("data") .. "/site/pack/packer/start/"
 
 a.describe("Packer post update hooks", function()
   local test_plugin_path = packer_path .. "test_plugin/"
   local run_hook = plugin_utils.post_update_hook
 
-  before_each(function()
-    vim.fn.mkdir(test_plugin_path, "p")
-  end)
+  before_each(function() vim.fn.mkdir(test_plugin_path, "p") end)
 
-  after_each(function()
-    vim.fn.delete(test_plugin_path, "rf")
-  end)
+  after_each(function() vim.fn.delete(test_plugin_path, "rf") end)
 
   a.it("should run the command in the correct folder", function()
     local plugin_spec = {
       name = "test/test_plugin",
       install_path = test_plugin_path,
-      run = "touch 'this_file_should_exist'",
+      run = "touch 'this_file_should_exist'"
     }
 
     await(run_hook(plugin_spec, {task_update = function() end}))

--- a/tests/packer_plugin_utils_spec.lua
+++ b/tests/packer_plugin_utils_spec.lua
@@ -8,7 +8,7 @@ a.describe("Packer post update hooks", function()
   local run_hook = plugin_utils.post_update_hook
 
   before_each(function()
-    vim.fn.mkdir(test_plugin_path)
+    vim.fn.mkdir(test_plugin_path, "p")
   end)
 
   after_each(function()

--- a/tests/plugin_utils_spec.lua
+++ b/tests/plugin_utils_spec.lua
@@ -1,0 +1,85 @@
+local a = require('plenary.async_lib.tests')
+local await = require('packer.async').wait
+local async = require('packer.async').sync
+local plugin_utils = require('packer.plugin_utils')
+local helpers = require("tests.helpers")
+
+local fmt = string.format
+
+a.describe('Plugin utils -', function()
+
+  a.describe('find_missing_plugins', function()
+    local repo_name = "test.nvim"
+    local path
+
+    plugin_utils.cfg({ start_dir = helpers.base_dir })
+
+    before_each(function ()
+      path = helpers.create_git_dir(repo_name)
+    end)
+
+    after_each(function ()
+      helpers.cleanup_dirs("tmp/packer")
+    end)
+
+    a.it('should pick up plugins with a different remote URL', function()
+      local test_repo_name = fmt('user2/%s', repo_name)
+      local plugins = {
+        [repo_name] = {
+          opt = false,
+          type = "git",
+          name = fmt("user1/%s", repo_name),
+          short_name = repo_name,
+          remote_url = function ()
+            return async(function()
+              return {ok = {remote = fmt('https://github.com/%s', test_repo_name)}}
+            end)
+          end
+        },
+      }
+      local result = await(plugin_utils.find_missing_plugins(plugins, {}, {[path] = true}))
+      assert.truthy(result)
+      assert.equal(1, #result)
+    end)
+
+    a.it('should not pick up plugins with the same remote URL', function()
+      local test_repo_name = fmt('user1/%s', repo_name)
+      local plugins = {
+        [repo_name] = {
+          opt = false,
+          type = "git",
+          name = test_repo_name,
+          short_name = repo_name,
+          remote_url = function ()
+            return async(function()
+              return {ok = {remote = fmt('https://github.com/%s', test_repo_name)}}
+            end)
+          end
+        },
+      }
+      local result = await(plugin_utils.find_missing_plugins(plugins, {}, {[path] = true}))
+      assert.truthy(result)
+      assert.equal(0, #result)
+    end)
+
+    a.it('should handle ssh git urls', function ()
+      local test_repo_name = fmt('user2/%s', repo_name)
+      local plugins = {
+        [repo_name] = {
+          opt = false,
+          type = "git",
+          name = fmt("user1/%s", repo_name),
+          short_name = repo_name,
+          remote_url = function ()
+            return async(function()
+              return {ok = {remote = fmt('git@github.com:%s.git', test_repo_name)}}
+            end)
+          end
+        },
+      }
+      local result = await(plugin_utils.find_missing_plugins(plugins, {}, {[path] = true}))
+      assert.truthy(result)
+      assert.equal(1, #result)
+    end)
+  end)
+end)

--- a/tests/plugin_utils_spec.lua
+++ b/tests/plugin_utils_spec.lua
@@ -12,15 +12,11 @@ a.describe('Plugin utils -', function()
     local repo_name = "test.nvim"
     local path
 
-    plugin_utils.cfg({ start_dir = helpers.base_dir })
+    plugin_utils.cfg({start_dir = helpers.base_dir})
 
-    before_each(function ()
-      path = helpers.create_git_dir(repo_name)
-    end)
+    before_each(function() path = helpers.create_git_dir(repo_name) end)
 
-    after_each(function ()
-      helpers.cleanup_dirs("tmp/packer")
-    end)
+    after_each(function() helpers.cleanup_dirs("tmp/packer") end)
 
     a.it('should pick up plugins with a different remote URL', function()
       local test_repo_name = fmt('user2/%s', repo_name)
@@ -30,12 +26,12 @@ a.describe('Plugin utils -', function()
           type = "git",
           name = fmt("user1/%s", repo_name),
           short_name = repo_name,
-          remote_url = function ()
+          remote_url = function()
             return async(function()
               return {ok = {remote = fmt('https://github.com/%s', test_repo_name)}}
             end)
           end
-        },
+        }
       }
       local result = await(plugin_utils.find_missing_plugins(plugins, {}, {[path] = true}))
       assert.truthy(result)
@@ -50,19 +46,19 @@ a.describe('Plugin utils -', function()
           type = "git",
           name = test_repo_name,
           short_name = repo_name,
-          remote_url = function ()
+          remote_url = function()
             return async(function()
               return {ok = {remote = fmt('https://github.com/%s', test_repo_name)}}
             end)
           end
-        },
+        }
       }
       local result = await(plugin_utils.find_missing_plugins(plugins, {}, {[path] = true}))
       assert.truthy(result)
       assert.equal(0, #result)
     end)
 
-    a.it('should handle ssh git urls', function ()
+    a.it('should handle ssh git urls', function()
       local test_repo_name = fmt('user2/%s', repo_name)
       local plugins = {
         [repo_name] = {
@@ -70,12 +66,12 @@ a.describe('Plugin utils -', function()
           type = "git",
           name = fmt("user1/%s", repo_name),
           short_name = repo_name,
-          remote_url = function ()
+          remote_url = function()
             return async(function()
               return {ok = {remote = fmt('git@github.com:%s.git', test_repo_name)}}
             end)
           end
-        },
+        }
       }
       local result = await(plugin_utils.find_missing_plugins(plugins, {}, {[path] = true}))
       assert.truthy(result)


### PR DESCRIPTION
This PR adds in an async check whilst cleaning,updating, and installing plugins i.e. places where the `find_missing_plugins` function was being used, for a git plugins remote url and checks if the repo name from the plugin matches the plugins name in memory, if it doesn't the plugin is marked as missing.

This will fix #231 

### TODO
- [x] Figure out why/how to correctly await `vim.schedule` in `find_missing_plugins`
- [x] Tidy up git command i.e. add to config?? - No because we need a consistent result here
- [x] Tidy up extraction of repo name from remote url
- [x] Ensure plugin is correctly removed/installed if url is different (this should work but just needs more testing)