### PR TITLE
Fix highlight being disabled due to redrawtimeout

### DIFF
--- a/lua/packer/display.lua
+++ b/lua/packer/display.lua
@@ -590,30 +590,39 @@ display_mt.__index = display_mt
 
 -- TODO: Option for no colors
 local function make_filetype_cmds(working_sym, done_sym, error_sym)
+  local function look_back(str)
+    return string.format([[\(%s\)\@%d<=]], str, #str)
+  end
   return {
     -- Adapted from https://github.com/kristijanhusak/vim-packager
     'setlocal buftype=nofile bufhidden=wipe nobuflisted nolist noswapfile nowrap nospell nonumber norelativenumber nofoldenable signcolumn=no',
-    'syntax clear', 'syn match packerWorking /^ ' .. working_sym .. '/',
+    'syntax clear',
+    'syn match packerWorking /^ ' .. working_sym .. '/',
     'syn match packerSuccess /^ ' .. done_sym .. '/',
     'syn match packerFail /^ ' .. error_sym .. '/',
-    'syn match packerStatus /\\(^+.*—\\)\\@<=\\s.*$/',
-    'syn match packerStatusSuccess /\\(^ ' .. done_sym .. '.*\\)\\@<=\\s.*$/',
-    'syn match packerStatusFail /\\(^ ' .. error_sym .. '.*\\)\\@<=\\s.*$/',
-    'syn match packerStatusCommit /\\(^\\*.*—\\)\\@<=\\s.*$/',
+    'syn match packerStatus /^+.*—\\zs\\s.*$/',
+    'syn match packerStatusSuccess /' .. look_back('^ ' .. done_sym) .. '\\s.*$/',
+    'syn match packerStatusFail /' .. look_back('^ ' .. error_sym) .. '\\s.*$/',
+    'syn match packerStatusCommit /^\\*.*—\\zs\\s.*$/',
     'syn match packerHash /\\(\\s\\)[0-9a-f]\\{7,8}\\(\\s\\)/',
-    'syn match packerRelDate /([^)]*)$/', 'syn match packerProgress /\\(\\[\\)\\@<=[\\=]*/',
+    'syn match packerRelDate /([^)]*)$/',
+    'syn match packerProgress /\\[\\zs[\\=]*/',
     'syn match packerOutput /\\(Output:\\)\\|\\(Commits:\\)\\|\\(Errors:\\)/',
     [[syn match packerTimeHigh /\d\{3\}\.\d\+ms/]],
     [[syn match packerTimeMedium /\d\{2\}\.\d\+ms/]],
     [[syn match packerTimeLow /\d\.\d\+ms/]],
     [[syn match packerTimeTrivial /0\.\d\+ms/]],
     [[syn match packerPackageNotLoaded /(not loaded)$/]],
-    [[syn match packerPackageName /\(^\ • \)\@<=[^ ]*/]],
+    [[syn match packerPackageName /^\ • \zs[^ ]*/]],
     [[syn match packerString /\v(''|""|(['"]).{-}[^\\]\2)/]],
     [[syn match packerBool /\<\(false\|true\)\>/]],
-    'hi def link packerWorking        SpecialKey', 'hi def link packerSuccess        Question',
-    'hi def link packerFail           ErrorMsg', 'hi def link packerHash           Identifier',
-    'hi def link packerRelDate        Comment', 'hi def link packerProgress       Boolean',
+
+    'hi def link packerWorking        SpecialKey',
+    'hi def link packerSuccess        Question',
+    'hi def link packerFail           ErrorMsg',
+    'hi def link packerHash           Identifier',
+    'hi def link packerRelDate        Comment',
+    'hi def link packerProgress       Boolean',
     'hi def link packerOutput         Type'
   }
 end

--- a/lua/packer/display.lua
+++ b/lua/packer/display.lua
@@ -588,11 +588,10 @@ local display_mt = {
 
 display_mt.__index = display_mt
 
+local function look_back(str) return string.format([[\(%s\)\@%d<=]], str, #str) end
+
 -- TODO: Option for no colors
 local function make_filetype_cmds(working_sym, done_sym, error_sym)
-  local function look_back(str)
-    return string.format([[\(%s\)\@%d<=]], str, #str)
-  end
   return {
     -- Adapted from https://github.com/kristijanhusak/vim-packager
     'setlocal buftype=nofile bufhidden=wipe nobuflisted nolist noswapfile nowrap nospell nonumber norelativenumber nofoldenable signcolumn=no',

--- a/lua/packer/display.lua
+++ b/lua/packer/display.lua
@@ -145,7 +145,7 @@ local function prompt_user(headline, body, callback)
     row = y,
     focusable = false,
     style = 'minimal',
-    border = config.prompt_border,
+    border = config.prompt_border
   }
 
   local win = api.nvim_open_win(buf, false, opts)
@@ -268,7 +268,7 @@ local display_mt = {
     for _, c in ipairs(highlights) do vim.cmd(c) end
   end,
 
-  setup_profile_syntax = function (_)
+  setup_profile_syntax = function(_)
     local highlights = {
       'hi def link packerTimeHigh WarningMsg', 'hi def link packerTimeMedium Float',
       'hi def link packerTimeLow String', 'hi def link packerTimeTrivial Comment'
@@ -471,12 +471,10 @@ local display_mt = {
     end
   end,
 
-  profile_output = function (self, output)
+  profile_output = function(self, output)
     self:setup_profile_syntax()
     local result = {}
-    for i, line in ipairs(output) do
-      result[i] = string.rep(" ", 2) .. line
-    end
+    for i, line in ipairs(output) do result[i] = string.rep(" ", 2) .. line end
     self:set_lines(config.header_lines, -1, result)
   end,
 
@@ -595,34 +593,25 @@ local function make_filetype_cmds(working_sym, done_sym, error_sym)
   return {
     -- Adapted from https://github.com/kristijanhusak/vim-packager
     'setlocal buftype=nofile bufhidden=wipe nobuflisted nolist noswapfile nowrap nospell nonumber norelativenumber nofoldenable signcolumn=no',
-    'syntax clear',
-    'syn match packerWorking /^ ' .. working_sym .. '/',
+    'syntax clear', 'syn match packerWorking /^ ' .. working_sym .. '/',
     'syn match packerSuccess /^ ' .. done_sym .. '/',
-    'syn match packerFail /^ ' .. error_sym .. '/',
-    'syn match packerStatus /^+.*—\\zs\\s.*$/',
+    'syn match packerFail /^ ' .. error_sym .. '/', 'syn match packerStatus /^+.*—\\zs\\s.*$/',
     'syn match packerStatusSuccess /' .. look_back('^ ' .. done_sym) .. '\\s.*$/',
     'syn match packerStatusFail /' .. look_back('^ ' .. error_sym) .. '\\s.*$/',
     'syn match packerStatusCommit /^\\*.*—\\zs\\s.*$/',
     'syn match packerHash /\\(\\s\\)[0-9a-f]\\{7,8}\\(\\s\\)/',
-    'syn match packerRelDate /([^)]*)$/',
-    'syn match packerProgress /\\[\\zs[\\=]*/',
+    'syn match packerRelDate /([^)]*)$/', 'syn match packerProgress /\\[\\zs[\\=]*/',
     'syn match packerOutput /\\(Output:\\)\\|\\(Commits:\\)\\|\\(Errors:\\)/',
     [[syn match packerTimeHigh /\d\{3\}\.\d\+ms/]],
-    [[syn match packerTimeMedium /\d\{2\}\.\d\+ms/]],
-    [[syn match packerTimeLow /\d\.\d\+ms/]],
+    [[syn match packerTimeMedium /\d\{2\}\.\d\+ms/]], [[syn match packerTimeLow /\d\.\d\+ms/]],
     [[syn match packerTimeTrivial /0\.\d\+ms/]],
     [[syn match packerPackageNotLoaded /(not loaded)$/]],
     [[syn match packerPackageName /^\ • \zs[^ ]*/]],
     [[syn match packerString /\v(''|""|(['"]).{-}[^\\]\2)/]],
-    [[syn match packerBool /\<\(false\|true\)\>/]],
-
-    'hi def link packerWorking        SpecialKey',
-    'hi def link packerSuccess        Question',
-    'hi def link packerFail           ErrorMsg',
-    'hi def link packerHash           Identifier',
-    'hi def link packerRelDate        Comment',
-    'hi def link packerProgress       Boolean',
-    'hi def link packerOutput         Type'
+    [[syn match packerBool /\<\(false\|true\)\>/]], 'hi def link packerWorking        SpecialKey',
+    'hi def link packerSuccess        Question', 'hi def link packerFail           ErrorMsg',
+    'hi def link packerHash           Identifier', 'hi def link packerRelDate        Comment',
+    'hi def link packerProgress       Boolean', 'hi def link packerOutput         Type'
   }
 end
 


### PR DESCRIPTION
According to docs `\@<=` is really inefficient and recommends using `\\zs` instead of it . 

### Doc
```
\@<=	Matches with zero width if the preceding atom matches just before what
	follows. |/zero-width|
	Like "(?<=pattern)" in Perl, but Vim allows non-fixed-width patterns.
	Example			matches ~
	\(an\_s\+\)\@<=file	"file" after "an" and white space or an
				end-of-line
	For speed it's often much better to avoid this multi.  Try using "\zs"
	instead |/\zs|.  To match the same as the above example:
		an\_s\+\zsfile
	At least set a limit for the look-behind, see below.

	"\@<=" and "\@<!" check for matches just before what follows.
	Theoretically these matches could start anywhere before this position.
	But to limit the time needed, only the line where what follows matches
	is searched, and one line before that (if there is one).  This should
	be sufficient to match most things and not be too slow.

	In the old regexp engine the part of the pattern after "\@<=" and
	"\@<!" are checked for a match first, thus things like "\1" don't work
	to reference \(\) inside the preceding atom.  It does work the other
	way around:
	Bad example			matches ~
	\%#=1\1\@<=,\([a-z]\+\)		",abc" in "abc,abc"

	However, the new regexp engine works differently, it is better to not
	rely on this behavior, do not use \@<= if it can be avoided:
	Example				matches ~
	\([a-z]\+\)\zs,\1		",abc" in "abc,abc"

```

### Changes 
I've replace the `\@<=` with `\zs` in syntax rules. I've cleaned all the plugins and installed them in those 29 seconds highlight didn't disapear so That's an improvement :D

For packerStatusSuccess and packerStatusFail I've limited their look behind to 5 bytes . Couldn't get them to work with `\zs` . I'm assuming it's because both `^ working_sym` is already matches packerSuccess. Navertheless looking behind 5 bytes instead of till start of file still better

I'm actually not sure how to test all possible highlights. So anyone reviewing please test it out and let me know if any syntax highlighting is off.

@akinsho can you check if you can repoduce [it](https://github.com/wbthomason/packer.nvim/issues/299#issuecomment-824208219) in this branch ?

closes #323