### PR TITLE
Enhance: don't panic on config error at startup

### DIFF
--- a/lua/packer/compile.lua
+++ b/lua/packer/compile.lua
@@ -89,8 +89,9 @@ local try_loadstring = [[
 local function try_loadstring(s, component, name)
   local success, result = pcall(loadstring(s))
   if not success then
-    print('Error running ' .. component .. ' for ' .. name)
-    error(result)
+    vim.schedule(function()
+      vim.api.nvim_notify('Packer: Error running ' .. component .. ' for ' .. name..'\n        '..result, vim.log.levels.ERROR, {})
+    end)
   end
   return result
 end

--- a/lua/packer/compile.lua
+++ b/lua/packer/compile.lua
@@ -90,7 +90,7 @@ local function try_loadstring(s, component, name)
   local success, result = pcall(loadstring(s))
   if not success then
     vim.schedule(function()
-      vim.api.nvim_notify('Packer: Error running ' .. component .. ' for ' .. name..'\n        '..result, vim.log.levels.ERROR, {})
+      vim.api.nvim_notify('packer.nvim: Error running ' .. component .. ' for ' .. name .. ': ' .. result, vim.log.levels.ERROR, {})
     end)
   end
   return result


### PR DESCRIPTION
### Prevent packer from panicking for config error

Currently if a error occurs while running config for a startup plugin. Packer panics and doesn't load any other plugin, neither does create lazy loading bindings . This patch changes that . With this packer will show an error message for failure and go on with usual business .

There's no point in throwing an error when call to `try_loadstring` is unprotected . Instead error message can be displayed with `nvim_echo` and error is gracefully handled inside `try_loadstring`. Also in my opinion `try` should mean it anticipates an error and handles it without causing a new one :P

### Motivation

I found current behavior really annoying especially when experimenting with plugins . As an error in one plugin just takes down the entire setup .