### PR TITLE
refactor(plugin_utils): use `cwd` instead of `cd` 

### DIFF
--- a/lua/packer/jobs.lua
+++ b/lua/packer/jobs.lua
@@ -180,6 +180,8 @@ local run_job = function(task, opts)
       options.timeout = 1000 * opts.timeout
     end
 
+    options.cwd = opts.cwd
+
     local stdin = loop.new_pipe(false)
     options.args = {unpack(task, 2)}
     options.stdio = {stdin, stdout, stderr}

--- a/lua/packer/plugin_utils.lua
+++ b/lua/packer/plugin_utils.lua
@@ -174,10 +174,8 @@ plugin_utils.post_update_hook = function(plugin, disp)
             stdout = jobs.logging_callback(hook_output.err, hook_output.output, nil, disp,
                                            plugin_name)
           }
-          local cmd = {
-            os.getenv('SHELL'), '-c', 'cd ' .. plugin.install_path .. ' && ' .. plugin.run
-          }
-          return await(jobs.run(cmd, {capture_output = hook_callbacks})):map_err(
+          local cmd = {os.getenv('SHELL') or vim.o.shell, '-c', plugin.run}
+          return await(jobs.run(cmd, {capture_output = hook_callbacks, cwd = plugin.install_path})):map_err(
                    function(err)
               return {
                 msg = string.format('Error running post update hook: %s',

--- a/tests/packer_plugin_utils_spec.lua
+++ b/tests/packer_plugin_utils_spec.lua
@@ -1,0 +1,29 @@
+local a = require('plenary.async_lib.tests')
+local await = require('packer.async').wait
+local plugin_utils = require("packer.plugin_utils")
+local packer_path = vim.fn.stdpath("data").."/site/pack/packer/start/"
+
+a.describe("Packer post update hooks", function()
+  local test_plugin_path = packer_path .. "test_plugin/"
+  local run_hook = plugin_utils.post_update_hook
+
+  before_each(function()
+    vim.fn.mkdir(test_plugin_path)
+  end)
+
+  after_each(function()
+    vim.fn.delete(test_plugin_path, "rf")
+  end)
+
+  a.it("should run the command in the correct folder", function()
+    local plugin_spec = {
+      name = "test/test_plugin",
+      install_path = test_plugin_path,
+      run = "touch 'this_file_should_exist'",
+    }
+
+    await(run_hook(plugin_spec, {task_update = function() end}))
+
+    assert.truthy(vim.loop.fs_stat(test_plugin_path .. "this_file_should_exist"))
+  end)
+end)


### PR DESCRIPTION
This PR changes how `packer` handles the current directory for post-update hooks by using the `cwd` option rather than `cd`-ing into the directory

This is mainly for compatibility across platforms since not all shells support the `&&` operator (IIRC older versions of `fish` didn't).

(Note: it might be useful to investigate the `'shell'` and `'shellcmdflag'` options to make this even more portable)

About the test:

It was not obvious to me how to test an async function, so I ended up leveraging `plenary`'s async test functions. That means I'm using `packer`'s `await()` function inside a `plenary` `Future`. Now, this works (probably because both are sugar over coroutines with similar APIs), but it might be too much of a hack for your taste

@akinsho I'd be curious to know whether this PR improves the situation you describe in #338