### PR TITLE
Fix incorrect argument passed to util.float

### DIFF
--- a/lua/packer/util.lua
+++ b/lua/packer/util.lua
@@ -110,6 +110,14 @@ util.float = function(opts)
   local left = math.ceil((columns - width) * 0.5)
   local top = math.ceil((lines - height) * 0.5 - 1)
 
+  --- TODO: this is an impromptu fix for
+  --- https://github.com/wbthomason/packer.nvim/pull/325#issuecomment-832874005
+  --- ideally we should decide if the string argument passed to display openers is
+  --- required or not
+  if type(opts) ~= "table" then
+    opts = {}
+  end
+
   opts = vim.tbl_deep_extend('force', {
     relative = 'editor',
     style = 'minimal',


### PR DESCRIPTION
This was raised in https://github.com/wbthomason/packer.nvim/pull/325#issuecomment-832874005 that an unexpected argument is passed to `util.float` when used as the `open_fn` for packer's display. This PR fixes this issue by checking the `opts` args type before trying to use it in the deep extend function