### PR TITLE
fix(display): use `close` instead of `pclose`

### DIFF
--- a/lua/packer/display.lua
+++ b/lua/packer/display.lua
@@ -243,7 +243,7 @@ local display_mt = {
     vim.bo.buftype = "nofile"
     vim.bo.buflisted = false
     vim.api.nvim_buf_set_lines(0, 0, -1, false, lines)
-    vim.api.nvim_buf_set_keymap(0, "n", "q", "<cmd>pclose!<CR>",
+    vim.api.nvim_buf_set_keymap(0, "n", "q", "<cmd>close!<CR>",
                                 {silent = true, noremap = true, nowait = true})
   end,
 


### PR DESCRIPTION
AFAIK, pclose usually used outside preview window.
Buffer map q to pclose is not necessary when we're inside preview window.

And it doesn't work when move preview window to new tabpage by `<C-w>T`.