### PR TITLE
refactor(local): use libuv to create symlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ Have a problem or idea? Make an [issue](https://github.com/wbthomason/packer.nvi
 ## Requirements
 - You need to be running Neovim v0.5.0+; `packer` makes use of extmarks and other newly-added Neovim
   features.
-- If you are on Windows 10, you need developer mode enabled in order to use local plugins (`packer`
-  needs to use `mklink`, which requires admin privileges - credit to @TimUntersberger for this note)
+- If you are on Windows 10, you need developer mode enabled in order to use local plugins (creating
+  symbolic links requires admin privileges on Windows - credit to @TimUntersberger for this note)
 
 ## Quickstart
 To get started, first clone this repository to somewhere on your `packpath`, e.g.:

--- a/doc/packer.txt
+++ b/doc/packer.txt
@@ -26,7 +26,7 @@ REQUIREMENTS                                     *packer-intro-requirements*
   on this to detect whether you are running Windows or a Unix-like OS (for path
   separators)
 - If you are on Windows 10, you need developer mode enabled in order to use
-  local plugins (`packer` needs to use `mklink`, which requires admin privileges
+  local plugins (creating symbolic links requires admin privileges on Windows
   - credit to @TimUntersberger for this note)
 
 ==============================================================================

--- a/lua/packer/plugin_types/local.lua
+++ b/lua/packer/plugin_types/local.lua
@@ -1,5 +1,4 @@
 local a = require('packer.async')
-local jobs = require('packer.jobs')
 local log = require('packer.log')
 local util = require('packer.util')
 local result = require('packer.result')
@@ -9,29 +8,23 @@ local await = a.wait
 
 local config = nil
 local function cfg(_config) config = _config end
-local job_opts = {capture_output = true}
+
+local symlink = a.wrap(vim.loop.fs_symlink)
 
 local function setup_local(plugin)
   local from = plugin.path
   local to = plugin.install_path
-  local task
-
-  if vim.fn.executable('ln') == 1 then
-    task = {'ln', '-sf', from, to}
-    -- NOTE: We assume mklink is present on Windows because executable() is apparently not reliable
-    -- (see issue #49)
-  elseif util.is_windows then
-    task = {'cmd', '/C', 'mklink', '/d', to, from}
-  else
-    log.error('No executable symlink command found!')
-    return
-  end
 
   local plugin_name = util.get_plugin_full_name(plugin)
   plugin.installer = function(disp)
     return async(function()
       disp:task_update(plugin_name, 'making symlink...')
-      return await(jobs.run(task, job_opts))
+      local err, success = await(symlink(from, to, {dir = true}))
+      if not success then
+        plugin.output = {err = {err}}
+        return result.err(err)
+      end
+      return result.ok()
     end)
   end
 

--- a/tests/local_plugin_spec.lua
+++ b/tests/local_plugin_spec.lua
@@ -1,0 +1,33 @@
+local a = require('plenary.async_lib.tests')
+local await = require('packer.async').wait
+local local_plugin = require('packer.plugin_types.local')
+local packer_path = vim.fn.stdpath('data') .. '/site/pack/packer/start/'
+local helpers = require('tests.helpers')
+
+a.describe('Local plugin -', function()
+  a.describe('installer', function()
+    local local_plugin_path
+    local repo_name = 'test.nvim'
+    local plugin_install_path = packer_path .. repo_name
+
+    before_each(function()
+      vim.fn.mkdir(packer_path, 'p')
+      local_plugin_path = helpers.create_git_dir(repo_name)
+    end)
+
+    after_each(function() helpers.cleanup_dirs(local_plugin_path, plugin_install_path) end)
+
+    a.it('should create a symlink', function()
+      local plugin_spec = {
+        name = local_plugin_path,
+        path = local_plugin_path,
+        install_path = plugin_install_path
+      }
+
+      local_plugin.setup(plugin_spec)
+      await(plugin_spec.installer({task_update = function() end}))
+
+      assert.equal('link', vim.loop.fs_lstat(plugin_install_path).type)
+    end)
+  end)
+end)


### PR DESCRIPTION
This PR replaces the use of external programs to create symlinks with the built-in `vim.loop.fs_symlink()` and adds a test for local plugins

EDIT: I've verified that this works on Windows 8.1 while running neovim-qt as administrator. I'm actually unsure whether developer mode on Windows 10 allows all programs to create symlinks or just `mklink`.

EDIT2: Apparently `libuv` calls the `CreateSymbolicLink` API with the `SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE` flag so this should work in theory, but I don't have a copy of Windows 10 to test this with