### PR TITLE
Fix #378: Normalize separator direction in detecting plugin repo changes

### DIFF
--- a/lua/packer/plugin_utils.lua
+++ b/lua/packer/plugin_utils.lua
@@ -131,7 +131,9 @@ plugin_utils.find_missing_plugins = function(plugins, opt_plugins, start_plugins
             -- protocol
             local normalized_remote = remote:gsub("https://", ""):gsub("ssh://git@", "")
             local normalized_plugin_name = plugin.name:gsub("https://", ""):gsub("ssh://git@", "")
-            if (normalized_remote ~= normalized_plugin_name) and (repo_name ~= plugin.name) then
+                                             :gsub("\\", "/")
+            if (normalized_remote ~= normalized_plugin_name)
+              and (repo_name ~= normalized_plugin_name) then
               table.insert(missing_plugins, plugin_name)
             end
           end


### PR DESCRIPTION
Fixes the bug @uyha reported in the comments of #378, by normalizing the separators in plugin names to match URL separators (i.e. always use `/` instead of Windows' `\`).

@uyha, could you please confirm that this solves the problem? I think it will, but I don't have access to a Windows testing environment, so I'm unsure.