### PR TITLE
Use Lua instead of Vimscript for the generated `packer_compiled` file

### DIFF
--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -26,7 +26,7 @@ local packer = {}
 local config_defaults = {
   ensure_dependencies = true,
   package_root = util.join_paths(vim.fn.stdpath('data'), 'site', 'pack'),
-  compile_path = util.join_paths(vim.fn.stdpath('config'), 'lua', 'plugin', 'packer_compiled.lua'),
+  compile_path = util.join_paths(vim.fn.stdpath('config'), 'plugin', 'packer_compiled.vim'),
   plugin_package = 'packer',
   max_jobs = nil,
   auto_clean = true,
@@ -487,7 +487,7 @@ packer.compile = function(raw_args)
   local output_file = io.open(output_path, 'w')
   output_file:write(compiled_loader)
   output_file:close()
-  if config.auto_reload_compiled then dofile(output_path) end
+  if config.auto_reload_compiled then vim.cmd("source " .. output_path) end
   log.info('Finished compiling lazy-loaders!')
   packer.on_compile_done()
 end

--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -26,7 +26,7 @@ local packer = {}
 local config_defaults = {
   ensure_dependencies = true,
   package_root = util.join_paths(vim.fn.stdpath('data'), 'site', 'pack'),
-  compile_path = util.join_paths(vim.fn.stdpath('config'), 'plugin', 'packer_compiled.vim'),
+  compile_path = util.join_paths(vim.fn.stdpath('config'), 'lua', 'plugin', 'packer_compiled.lua'),
   plugin_package = 'packer',
   max_jobs = nil,
   auto_clean = true,
@@ -487,7 +487,7 @@ packer.compile = function(raw_args)
   local output_file = io.open(output_path, 'w')
   output_file:write(compiled_loader)
   output_file:close()
-  if config.auto_reload_compiled then vim.cmd("source " .. output_path) end
+  if config.auto_reload_compiled then dofile(output_path) end
   log.info('Finished compiling lazy-loaders!')
   packer.on_compile_done()
 end

--- a/lua/packer/compile.lua
+++ b/lua/packer/compile.lua
@@ -7,27 +7,33 @@ local luarocks = require('packer.luarocks')
 local config
 local function cfg(_config) config = _config.profile end
 
-local feature_guard = [[
-if !has('nvim-0.5')
+local feature_guard = [=[
+if vim.fn.has('nvim-0.5') ~= 1 then
+  vim.cmd([[
   echohl WarningMsg
   echom "Invalid Neovim version for packer.nvim!"
   echohl None
   finish
-endif
+  ]])
+end
 
-packadd packer.nvim
+vim.cmd('packadd packer.nvim')
 
-try
-]]
+local comp_success, _ = pcall(function()
+]=]
 
-local catch_errors = [[
-catch
+local catch_errors = [=[
+end)
+
+if not comp_success then
+  vim.cmd([[
   echohl ErrorMsg
   echom "Error in packer_compiled: " .. v:exception
   echom "Please check your config for correctness"
   echohl None
-endtry
-]]
+  ]])
+end
+]=]
 
 ---@param should_profile boolean
 ---@return string
@@ -561,9 +567,8 @@ local function make_loaders(_, plugins, should_profile)
   -- Output everything:
 
   -- First, the Lua code
-  local result = {'" Automatically generated packer.nvim plugin loader code\n'}
+  local result = {'-- Automatically generated packer.nvim plugin loader code\n'}
   table.insert(result, feature_guard)
-  table.insert(result, 'lua << END')
   table.insert(result, profile_time(should_profile))
   table.insert(result, profile_output)
   timed_chunk(luarocks.generate_path_setup(), 'Luarocks path setup', result)
@@ -645,7 +650,6 @@ local function make_loaders(_, plugins, should_profile)
   end
 
   table.insert(result, conditionally_output_profile(config.threshold))
-  table.insert(result, 'END\n')
   table.insert(result, catch_errors)
   return table.concat(result, '\n')
 end

--- a/lua/packer/compile.lua
+++ b/lua/packer/compile.lua
@@ -28,7 +28,7 @@ end)
 if not comp_success then
   vim.cmd([[
   echohl ErrorMsg
-  echom "Error in packer_compiled: " .. comp_err
+  echom "Error in packer_compiled: "]] .. comp_err .. [[
   echom "Please check your config for correctness"
   echohl None
   ]])
@@ -567,7 +567,8 @@ local function make_loaders(_, plugins, should_profile)
   -- Output everything:
 
   -- First, the Lua code
-  local result = {'-- Automatically generated packer.nvim plugin loader code\n'}
+  local result = {'" Automatically generated packer.nvim plugin loader code\n'}
+  table.insert(result, 'lua << END')
   table.insert(result, feature_guard)
   table.insert(result, profile_time(should_profile))
   table.insert(result, profile_output)
@@ -651,6 +652,7 @@ local function make_loaders(_, plugins, should_profile)
 
   table.insert(result, conditionally_output_profile(config.threshold))
   table.insert(result, catch_errors)
+  table.insert(result, 'END\n')
   return table.concat(result, '\n')
 end
 

--- a/lua/packer/compile.lua
+++ b/lua/packer/compile.lua
@@ -19,7 +19,7 @@ end
 
 vim.cmd('packadd packer.nvim')
 
-local comp_success, _ = pcall(function()
+local comp_success, comp_err = pcall(function()
 ]=]
 
 local catch_errors = [=[
@@ -28,7 +28,7 @@ end)
 if not comp_success then
   vim.cmd([[
   echohl ErrorMsg
-  echom "Error in packer_compiled: " .. v:exception
+  echom "Error in packer_compiled: " .. comp_err
   echom "Please check your config for correctness"
   echohl None
   ]])


### PR DESCRIPTION
As the name of the PR indicates, it's intended to stop using Vimscript in the file produced on compilation by doing everything within a Lua block.