### PR TITLE
fix: use packer.load for plugins loaded via cond

### DIFF
--- a/lua/packer/compile.lua
+++ b/lua/packer/compile.lua
@@ -438,7 +438,9 @@ local function make_loaders(_, plugins, should_profile)
   for condition, names in pairs(condition_ids) do
     local conditional_loads = {}
     for _, name in ipairs(names) do
-      timed_chunk('\tvim.cmd [[packadd ' .. name .. ']]', 'packadd for ' .. name, conditional_loads)
+      timed_chunk(
+        fmt('\trequire("packer.load")({"%s"}, {}, _G.packer_plugins)', name),
+        'packadd for ' .. name, conditional_loads)
       if plugins[name].config then
         local lines = {'-- Config for: ' .. name}
         timed_chunk(plugins[name].executable_config, 'Config for ' .. name, lines)


### PR DESCRIPTION
Attempt to partially address #272 . @wbthomason you mentioned that `cond` plugins should use the load mechanism so the sequencing logic could be taken advantage of. I'm not sure whether just using `packer.load` is enough though since in a very brief test doing this seems to cause the `cond` plugin to load as expected but the `after` plugins do not