### PR TITLE
Big breaking change: Make the compiled file do less and implement autorecompilation

### DIFF
--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -543,6 +543,12 @@ end
 --- Update the compiled lazy-loader code
 --- Takes an optional argument of a path to which to output the resulting compiled code
 packer.compile = function(raw_args)
+  -- TODO: check if the user wants any compilation at all via a new config variable
+  -- TODO: remove a bunch of complexity from the compile module/maybe here once we don't need to
+  -- compile functions or sequencing
+  -- TODO: implement, for the compiled file, logic to check its values against the current config.
+  -- We can do this by computing an efficient hash of the lazy-loader strings and storing this in
+  -- the compiled file
   local compile = require_and_configure('compile')
   local log = require_and_configure('log')
 
@@ -657,6 +663,13 @@ packer.startup = function(spec)
   end
 
   return packer
+end
+
+packer.load = function()
+  -- TODO: This will be responsible for (1) sourcing the new, lighter, compiled file and (2)
+  -- handling things like running setup and config functions, sequencing, etc. 90% of this logic
+  -- already exists in the load module; the main thing to add is loading the new compiled file. This
+  -- function needs to be called at the end of startup()
 end
 
 return packer


### PR DESCRIPTION
@shadmansaleh @akinsho Now that #331 is merged, this PR will be the big breaking change to:
1. Require users to load their `packer` config always
2. Reduce the compiled file to lazy-loaders and any precomputed paths we can generate/luarocks setup
3. Change to use the "live" values from the spec for `setup` and `config` as well as `cond` and `after`
4. Implement autorecompilation by storing hashes of the strings that specify lazy-load conditions and regenerating the compiled file if the current values don't match
5. Move the default compiled file location to `stdpath('cache')`
6. Clean up the code while we're in there, try to use `luv` instead of e.g. `vim.fn` wherever possible, in general simplify and tidy things which have grown cruft over the course of `packer`'s existence so far.
