### PR TITLE
fix(README.md): refer to the correct noautocmd PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Have a problem or idea? Make an [issue](https://github.com/wbthomason/packer.nvi
 10. [Contributors](#contributors)
 
 ## Notices
-- **2021-06-06**: Your Neovim must include https://github.com/neovim/neovim/pull/14531; `packer` uses the `noautocmd` key.
+- **2021-06-06**: Your Neovim must include https://github.com/neovim/neovim/pull/14659; `packer` uses the `noautocmd` key.
 - **2021-04-19**: `packer` now provides built-in profiling for your config via the `packer_compiled`
   file. Take a look at [the docs](#profiling) for more information!
 - **2021-02-18**: Having trouble with Luarocks on macOS? See [this issue](https://github.com/wbthomason/packer.nvim/issues/180).


### PR DESCRIPTION
14531 temporarily reverted the behaviour of `nvim_open_win` for a few hours until `noautocmd` was merged in 14659, which caused some confusion upstream. :smile: