### PR TITLE
feat: open packer logs from display

### DIFF
--- a/doc/packer.txt
+++ b/doc/packer.txt
@@ -231,6 +231,7 @@ default values: >
         toggle_info = '<CR>',
         diff = 'd',
         prompt_revert = 'r',
+        open_log = 'l',
       }
     }
   }
@@ -459,6 +460,8 @@ Once an operation completes, the results are shown in the display window.
 q                    close the display window
 <CR>                 toggle information about a particular plugin
 r                    revert an update
+d                    show the diff for a particular commit
+l                    open the log file in a new tab
 
 They can be configured by changing the value of `config.display.keybindings`
 (see |packer-configuration|). Setting it to `false` will disable all keybindings.

--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -55,7 +55,7 @@ local config_defaults = {
     title = 'packer.nvim',
     show_all_info = true,
     prompt_border = 'double',
-    keybindings = { quit = 'q', toggle_info = '<CR>', diff = 'd', prompt_revert = 'r' },
+    keybindings = { quit = 'q', toggle_info = '<CR>', diff = 'd', prompt_revert = 'r', open_log = 'l' },
   },
   luarocks = { python_cmd = 'python' },
   log = { level = 'warn' },

--- a/lua/packer/display.lua
+++ b/lua/packer/display.lua
@@ -124,6 +124,10 @@ local keymaps = {
     rhs = '<cmd>lua require"packer.display".prompt_revert()<cr>',
     action = 'revert an update',
   },
+  open_log = {
+    rhs = '<cmd>lua require"packer.display".open_log()<cr>',
+    action = 'open packer logs',
+  },
 }
 
 --- The order of the keys in a dict-like table isn't guaranteed, meaning the display window can
@@ -133,6 +137,7 @@ local keymap_display_order = {
   [2] = 'toggle_info',
   [3] = 'diff',
   [4] = 'prompt_revert',
+  [5] = 'open_log',
 }
 
 --- Utility function to prompt a user with a question in a floating window
@@ -690,6 +695,21 @@ local display_mt = {
     end
   end,
 
+  open_log = function(self)
+    if not self:valid_display() then
+      return
+    end
+    if next(self.items) == nil then
+      log.info 'Operations are still running; plugin info is not ready yet'
+      return
+    end
+    log.open()
+    vim.cmd [[wincmd P]]
+    vim.bo.buflisted = false
+    vim.api.nvim_buf_set_keymap(0, 'n', 'q', '<cmd>close!<CR>', { silent = true, noremap = true, nowait = true })
+    vim.bo.filetype = 'log'
+  end,
+
   --- Heuristically find the plugin nearest to the cursor for displaying detailed information
   find_nearest_plugin = function(self)
     if not self:valid_display() then
@@ -854,5 +874,11 @@ end
 
 --- Async prompt_user
 display.ask_user = a.wrap(prompt_user)
+
+display.open_log = function()
+  if display.status.disp then
+    display.status.disp:open_log()
+  end
+end
 
 return display

--- a/lua/packer/display.lua
+++ b/lua/packer/display.lua
@@ -704,7 +704,7 @@ local display_mt = {
       return
     end
     log.open()
-    vim.cmd [[wincmd P]]
+    vim.wo.wrap = false
     vim.bo.buflisted = false
     vim.api.nvim_buf_set_keymap(0, 'n', 'q', '<cmd>close!<CR>', { silent = true, noremap = true, nowait = true })
     vim.bo.filetype = 'log'

--- a/lua/packer/display.lua
+++ b/lua/packer/display.lua
@@ -126,7 +126,7 @@ local keymaps = {
   },
   open_log = {
     rhs = '<cmd>lua require"packer.display".open_log()<cr>',
-    action = 'open packer logs',
+    action = 'open log file',
   },
 }
 

--- a/lua/packer/log.lua
+++ b/lua/packer/log.lua
@@ -169,7 +169,7 @@ log.new(default_config, true)
 function log.open()
   -- This should be consistent with the format mentioned in log.new above.
   local logfile = string.format('%s/%s.log', vim.fn.stdpath('cache'), default_config.plugin)
-  vim.cmd(string.format("pedit %s", logfile))
+  vim.cmd(string.format("tabedit + %s", logfile))
 end
 
 return log

--- a/lua/packer/log.lua
+++ b/lua/packer/log.lua
@@ -166,4 +166,10 @@ end
 log.new(default_config, true)
 -- }}}
 
+function log.open()
+  -- This should be consistent with the format mentioned in log.new above.
+  local logfile = string.format('%s/%s.log', vim.fn.stdpath('cache'), default_config.plugin)
+  vim.cmd(string.format("pedit %s", logfile))
+end
+
 return log


### PR DESCRIPTION
fixes: #409 

This is similar to the diff window.

We could also implement a command like `PackerLog` to open the log file.

Also, should we open it instead in a new tab as the lines could get pretty long?