### PR TITLE
Refactor: faster operation startup

### DIFF
--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -133,7 +133,7 @@ end
 --- Add a Luarocks package to be managed
 packer.use_rocks = function(rock)
   if type(rock) == 'string' then rock = {rock} end
-  if not vim.tbl_islist(rock) and type(rock[1]) == "string" then
+  if not vim.tbl_islist(rock) and type(rock[1]) == 'string' then
     rocks[rock[1]] = rock
   else
     for _, r in ipairs(rock) do

--- a/lua/packer/clean.lua
+++ b/lua/packer/clean.lua
@@ -20,6 +20,7 @@ end
 -- Find and remove any plugins not currently configured for use
 local clean_plugins = function(_, plugins, results)
   return async(function()
+    log.debug('Starting clean')
     local dirty_plugins = {}
     results = results or {}
     results.removals = results.removals or {}

--- a/lua/packer/clean.lua
+++ b/lua/packer/clean.lua
@@ -18,21 +18,15 @@ local function is_dirty(plugin, typ)
 end
 
 -- Find and remove any plugins not currently configured for use
-local clean_plugins = function(_, plugins, results)
+local clean_plugins = function(_, plugins, fs_state, results)
   return async(function()
     log.debug('Starting clean')
     local dirty_plugins = {}
     results = results or {}
     results.removals = results.removals or {}
-    await(a.main)
-    local opt_plugins, start_plugins = plugin_utils.list_installed_plugins()
-    local missing_plugins = await(plugin_utils.find_missing_plugins(plugins))
-    -- turn the list into a hashset-like structure
-    for idx, plugin_name in ipairs(missing_plugins) do
-      missing_plugins[plugin_name] = true
-      missing_plugins[idx] = nil
-    end
-
+    local opt_plugins = vim.deepcopy(fs_state.opt)
+    local start_plugins = vim.deepcopy(fs_state.start)
+    local missing_plugins = fs_state.missing
     -- test for dirty / 'missing' plugins
     for _, plugin_config in pairs(plugins) do
       local path = plugin_config.install_path
@@ -46,17 +40,21 @@ local clean_plugins = function(_, plugins, results)
       end
 
       -- We don't want to report paths which don't exist for removal; that will confuse people
-      local is_installed = vim.loop.fs_stat(path) ~= nil
-      local plugin_missing = missing_plugins[plugin_config.short_name] and is_installed
-      local disabled_but_installed = is_installed and plugin_config.disable
+      local path_exists = false
+      if missing_plugins[plugin_config.short_name] or plugin_config.disable then
+        path_exists = vim.loop.fs_stat(path) ~= nil
+      end
+
+      local plugin_missing = path_exists and missing_plugins[plugin_config.short_name]
+      local disabled_but_installed = path_exists and plugin_config.disable
       if plugin_missing or is_dirty(plugin_config, plugin_source) or disabled_but_installed then
-        table.insert(dirty_plugins, path)
+        dirty_plugins[#dirty_plugins + 1] = path
       end
     end
 
     -- Any path which was not set to `nil` above will be set to dirty here
     local function mark_remaining_as_dirty(plugin_list)
-      for path, _ in pairs(plugin_list) do table.insert(dirty_plugins, path) end
+      for path, _ in pairs(plugin_list) do dirty_plugins[#dirty_plugins + 1] = path end
     end
 
     mark_remaining_as_dirty(opt_plugins)
@@ -68,6 +66,7 @@ local clean_plugins = function(_, plugins, results)
       if await(display.ask_user('Removing the following directories. OK? (y/N)', lines)) then
         results.removals = dirty_plugins
         log.debug('Removed ' .. vim.inspect(dirty_plugins))
+        -- TODO: Maybe use LUV functions directly rather than os.execute
         if util.is_windows then
           for _, path in ipairs(dirty_plugins) do os.execute('cmd /C rmdir /S /Q ' .. path) end
         else

--- a/lua/packer/log.lua
+++ b/lua/packer/log.lua
@@ -126,7 +126,8 @@ log.new = function(config, standalone)
         return
       end
 
-      local str = string.format("[%-6s%s] %s: %s\n", nameupper, os.date(), lineinfo, msg)
+      local str = string.format("[%-6s%s %s] %s: %s\n", nameupper, os.date(), vim.loop.hrtime(),
+                                lineinfo, msg)
       fp:write(str)
       fp:close()
     end

--- a/lua/packer/luarocks.lua
+++ b/lua/packer/luarocks.lua
@@ -70,17 +70,15 @@ local function hererocks_installer(disp)
     }
 
     local opts = {capture_output = callbacks}
-    local r = await(jobs.run(hererocks_cmd, opts)):map_err(
-                function(err)
-        return {msg = 'Error installing hererocks', data = err, output = output}
-      end)
+    local r = await(jobs.run(hererocks_cmd, opts)):map_err(function(err)
+      return {msg = 'Error installing hererocks', data = err, output = output}
+    end)
 
     local luarocks_cmd = config.python_cmd .. ' ' .. hererocks_file .. ' --verbose -j '
                            .. lua_version.jit .. ' -r latest ' .. hererocks_install_dir
-    r:and_then(await, jobs.run(luarocks_cmd, opts)):map_ok(
-      function()
-        if disp then disp:task_succeeded('luarocks-hererocks', 'installed hererocks!') end
-      end):map_err(function(err)
+    r:and_then(await, jobs.run(luarocks_cmd, opts)):map_ok(function()
+      if disp then disp:task_succeeded('luarocks-hererocks', 'installed hererocks!') end
+    end):map_err(function(err)
       if disp then disp:task_failed('luarocks-hererocks', 'failed to install hererocks!') end
       log.error('Failed to install hererocks: ' .. vim.inspect(err))
       return {msg = 'Error installing luarocks', data = err, output = output}
@@ -254,8 +252,8 @@ local function luarocks_list(disp)
       local results = {}
       local output = chunk_output(data.output.data.stdout)
       for _, line in ipairs(output) do
-        for l_package, version, status, install_path in
-          string.gmatch(line, "([^\t]+)\t([^\t]+)\t([^\t]+)\t([^\t]+)") do
+        for l_package, version, status, install_path in string.gmatch(line,
+                                                                      "([^\t]+)\t([^\t]+)\t([^\t]+)\t([^\t]+)") do
           table.insert(results, {
             name = l_package,
             version = version,
@@ -326,7 +324,7 @@ local function uninstall_sync(packages)
   return async(function() return await(uninstall_packages(packages)) end)()
 end
 
-local function clean_packages(rocks, results, disp)
+local function clean_rocks(rocks, results, disp)
   return async(function()
     local r = result.ok()
     if not hererocks_is_setup() then return r end
@@ -403,7 +401,7 @@ local function clean_packages(rocks, results, disp)
   end)
 end
 
-local function ensure_packages(rocks, results, disp)
+local function ensure_rocks(rocks, results, disp)
   return async(function()
     local to_install = {}
     for _, rock in pairs(rocks) do
@@ -490,9 +488,9 @@ return {
   install_hererocks = hererocks_installer,
   setup_paths = setup_nvim_paths,
   uninstall = uninstall_sync,
-  clean = clean_packages,
+  clean = clean_rocks,
   install = install_sync,
-  ensure = ensure_packages,
+  ensure = ensure_rocks,
   generate_path_setup = generate_path_setup_code,
   cfg = cfg
 }

--- a/lua/packer/plugin_utils.lua
+++ b/lua/packer/plugin_utils.lua
@@ -48,20 +48,6 @@ plugin_utils.guess_dir_type = function(dir)
   end
 end
 
-plugin_utils.list_installed_plugins = function()
-  local opt_plugins = {}
-  local start_plugins = {}
-  for _, path in ipairs(vim.fn.globpath(config.opt_dir, '*', true, true)) do
-    opt_plugins[path] = true
-  end
-
-  for _, path in ipairs(vim.fn.globpath(config.start_dir, '*', true, true)) do
-    start_plugins[path] = true
-  end
-
-  return opt_plugins, start_plugins
-end
-
 plugin_utils.helptags_stale = function(dir)
   -- Adapted directly from minpac.vim
   local txts = vim.fn.glob(util.join_paths(dir, '*.txt'), true, true)
@@ -97,10 +83,39 @@ plugin_utils.ensure_dirs = function()
   if vim.fn.isdirectory(config.start_dir) == 0 then vim.fn.mkdir(config.start_dir, 'p') end
 end
 
+plugin_utils.list_installed_plugins = function()
+  local opt_plugins = {}
+  local start_plugins = {}
+  local opt_dir_handle = vim.loop.fs_opendir(config.opt_dir, nil, 50)
+  if opt_dir_handle then
+    local opt_dir_items = vim.loop.fs_readdir(opt_dir_handle)
+    while opt_dir_items do
+      for _, item in ipairs(opt_dir_items) do
+        opt_plugins[util.join_paths(config.opt_dir, item.name)] = true
+      end
+
+      opt_dir_items = vim.loop.fs_readdir(opt_dir_handle)
+    end
+  end
+
+  local start_dir_handle = vim.loop.fs_opendir(config.start_dir, nil, 50)
+  if start_dir_handle then
+    local start_dir_items = vim.loop.fs_readdir(start_dir_handle)
+    while start_dir_items do
+      for _, item in ipairs(start_dir_items) do
+        start_plugins[util.join_paths(config.start_dir, item.name)] = true
+      end
+
+      start_dir_items = vim.loop.fs_readdir(start_dir_handle)
+    end
+  end
+
+  return opt_plugins, start_plugins
+end
+
 plugin_utils.find_missing_plugins = function(plugins, opt_plugins, start_plugins)
   return a.sync(function()
     if opt_plugins == nil or start_plugins == nil then
-      await(a.main)
       opt_plugins, start_plugins = plugin_utils.list_installed_plugins()
     end
 

--- a/lua/packer/plugin_utils.lua
+++ b/lua/packer/plugin_utils.lua
@@ -132,7 +132,7 @@ plugin_utils.find_missing_plugins = function(plugins, opt_plugins, start_plugins
         await(a.main)
         local guessed_type = plugin_utils.guess_dir_type(plugin_path)
         if not plugin_installed or plugin.type ~= guessed_type then
-          table.insert(missing_plugins, plugin_name)
+          missing_plugins[plugin_name] = true
         elseif guessed_type == plugin_utils.git_plugin_type then
           local r = await(plugin.remote_url())
           local remote = r.ok and r.ok.remote or nil
@@ -149,7 +149,7 @@ plugin_utils.find_missing_plugins = function(plugins, opt_plugins, start_plugins
                                              :gsub("\\", "/")
             if (normalized_remote ~= normalized_plugin_name)
               and (repo_name ~= normalized_plugin_name) then
-              table.insert(missing_plugins, plugin_name)
+              missing_plugins[plugin_name] = true
             end
           end
         end

--- a/lua/packer/plugin_utils.lua
+++ b/lua/packer/plugin_utils.lua
@@ -145,6 +145,16 @@ plugin_utils.find_missing_plugins = function(plugins, opt_plugins, start_plugins
   end)
 end
 
+plugin_utils.get_fs_state = function(plugins)
+  log.debug('Updating FS state')
+  local opt_plugins, start_plugins = plugin_utils.list_installed_plugins()
+  return a.sync(function()
+    local missing_plugins = await(plugin_utils.find_missing_plugins(plugins, opt_plugins,
+                                                                    start_plugins))
+    return {opt = opt_plugins, start = start_plugins, missing = missing_plugins}
+  end)
+end
+
 plugin_utils.load_plugin = function(plugin)
   if plugin.opt then
     vim.cmd('packadd ' .. plugin.short_name)

--- a/lua/packer/update.lua
+++ b/lua/packer/update.lua
@@ -47,6 +47,7 @@ local function fix_plugin_type(plugin, results)
 end
 
 local function fix_plugin_types(plugins, plugin_names, results)
+  log.debug('Fixing plugin types')
   results = results or {}
   results.moves = results.moves or {}
   -- NOTE: This function can only be run on plugins already installed
@@ -57,6 +58,7 @@ local function fix_plugin_types(plugins, plugin_names, results)
                                         plugin.short_name)
     if vim.fn.isdirectory(install_dir) == 1 then fix_plugin_type(plugin, results) end
   end
+  log.debug('Done fixing plugin types')
 end
 
 local function update_plugin(plugin, display_win, results)

--- a/lua/packer/update.lua
+++ b/lua/packer/update.lua
@@ -24,15 +24,21 @@ end
 
 local function cfg(_config) config = _config end
 
-local function fix_plugin_type(plugin, results)
+local function fix_plugin_type(plugin, results, fs_state)
   local from
   local to
   if plugin.opt then
     from = util.join_paths(config.start_dir, plugin.short_name)
     to = util.join_paths(config.opt_dir, plugin.short_name)
+    fs_state.opt[to] = true
+    fs_state.start[from] = nil
+    fs_state.missing[plugin.short_name] = nil
   else
     from = util.join_paths(config.opt_dir, plugin.short_name)
     to = util.join_paths(config.start_dir, plugin.short_name)
+    fs_state.start[to] = true
+    fs_state.opt[from] = nil
+    fs_state.missing[plugin.short_name] = nil
   end
 
   -- NOTE: If we stored all plugins somewhere off-package-path and used symlinks to put them in the
@@ -46,17 +52,16 @@ local function fix_plugin_type(plugin, results)
   end
 end
 
-local function fix_plugin_types(plugins, plugin_names, results)
+local function fix_plugin_types(plugins, plugin_names, results, fs_state)
   log.debug('Fixing plugin types')
   results = results or {}
   results.moves = results.moves or {}
   -- NOTE: This function can only be run on plugins already installed
   for _, v in ipairs(plugin_names) do
     local plugin = plugins[v]
-    -- TODO: This will have to change when separate packages are implemented
     local install_dir = util.join_paths(plugin.opt and config.start_dir or config.opt_dir,
                                         plugin.short_name)
-    if vim.fn.isdirectory(install_dir) == 1 then fix_plugin_type(plugin, results) end
+    if vim.loop.fs_stat(install_dir) ~= nil then fix_plugin_type(plugin, results, fs_state) end
   end
   log.debug('Done fixing plugin types')
 end

--- a/lua/packer/util.lua
+++ b/lua/packer/util.lua
@@ -34,7 +34,7 @@ end
 if jit ~= nil then
   util.is_windows = jit.os == 'Windows'
 else
-  util.is_windows = package.config:sub(1,1) == '\\'
+  util.is_windows = package.config:sub(1, 1) == '\\'
 end
 
 util.get_separator = function()
@@ -103,9 +103,7 @@ util.float = function(opts)
   --- https://github.com/wbthomason/packer.nvim/pull/325#issuecomment-832874005
   --- ideally we should decide if the string argument passed to display openers is
   --- required or not
-  if type(opts) ~= "table" then
-    opts = {}
-  end
+  if type(opts) ~= "table" then opts = {} end
 
   opts = vim.tbl_deep_extend('force', {
     relative = 'editor',

--- a/tests/plugin_utils_spec.lua
+++ b/tests/plugin_utils_spec.lua
@@ -35,7 +35,7 @@ a.describe('Plugin utils -', function()
       }
       local result = await(plugin_utils.find_missing_plugins(plugins, {}, {[path] = true}))
       assert.truthy(result)
-      assert.equal(1, #result)
+      assert.equal(1, #vim.tbl_keys(result))
     end)
 
     a.it('should not pick up plugins with the same remote URL', function()
@@ -75,7 +75,7 @@ a.describe('Plugin utils -', function()
       }
       local result = await(plugin_utils.find_missing_plugins(plugins, {}, {[path] = true}))
       assert.truthy(result)
-      assert.equal(1, #result)
+      assert.equal(1, #vim.tbl_keys(result))
     end)
   end)
 end)


### PR DESCRIPTION
This refactoring primarily (1) refactors the main management operations to only read the state of the filesystem (e.g. look for installed/missing plugins) **once** and (2) adds finer-grained debug logging.

These changes are in response to the unusually high "time to display" that @cloggier mentioned on Gitter; for me, this version reduces the average time to display from 0.3s to 0.15s.

This PR also contains some minor renaming/reformatting.