### PR TITLE
Fix #423

### DIFF
--- a/lua/packer/compile.lua
+++ b/lua/packer/compile.lua
@@ -150,6 +150,7 @@ end
 local function dump_loaders(loaders)
   local result = vim.deepcopy(loaders)
   for k, _ in pairs(result) do
+    if result[k].only_setup or result[k].only_sequence then result[k].loaded = true end
     result[k].only_setup = nil
     result[k].only_sequence = nil
   end


### PR DESCRIPTION
Fixes #423 by marking a plugin as `loaded = true` in the dumped loaders table if it is only `opt` for purposes of a `setup` key or sequencing.