### PR TITLE
Add config.git.default_url_format to allow customizing default URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ default configuration values (and structure of the configuration table) are:
     },
     depth = 1, -- Git clone depth
     clone_timeout = 60, -- Timeout, in seconds, for git clones
+    default_url_format = 'https://github.com/%s' -- Lua format string used for "aaa/bbb" style plugins
   },
   display = {
     non_interactive = false, -- If true, disable display windows for all operations

--- a/doc/packer.txt
+++ b/doc/packer.txt
@@ -212,6 +212,7 @@ default values: >
       },
       depth = 1, -- Git clone depth
       clone_timeout = 60, -- Timeout, in seconds, for git clones
+      default_url_format = 'https://github.com/%s' -- Lua format string used for "aaa/bbb" style plugins
     },
     display = {
       non_interactive = false, -- If true, disable display windows for all operations

--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -39,7 +39,7 @@ local config_defaults = {
     },
     depth = 1,
     clone_timeout = 60,
-    default_url_format = 'https://github.com/%s'
+    default_url_format = 'https://github.com/%s.git'
   },
   display = {
     non_interactive = false,

--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -38,7 +38,8 @@ local config_defaults = {
       revert = '-C %s reset --hard HEAD@{1}'
     },
     depth = 1,
-    clone_timeout = 60
+    clone_timeout = 60,
+    default_url_format = 'https://github.com/%s'
   },
   display = {
     non_interactive = false,

--- a/lua/packer/plugin_utils.lua
+++ b/lua/packer/plugin_utils.lua
@@ -26,7 +26,7 @@ plugin_utils.guess_type = function(plugin)
     plugin.type = plugin_utils.git_plugin_type
   else
     local path = table.concat(vim.split(plugin.path, "\\", true), "/")
-    plugin.url = 'https://github.com/' .. path
+    plugin.url = string.format(config.git.default_url_format, path)
     plugin.type = plugin_utils.git_plugin_type
   end
 end


### PR DESCRIPTION
Closes #433. Introduces a new config variable, `config.git.default_url_format` which is a format string used in `plugin_utils` if a plugin is specified in the `aaa/bbb` form rather than with a full local path or URL. Allows users to customize the default source/URL pattern for plugins, as described in #433.

@jdhao, can you take a look and make sure this does what you wanted?