### PR TITLE
fix!: insert paths separately to avoid splitting

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ default configuration values (and structure of the configuration table) are:
     cmd = 'git', -- The base command for git operations
     subcommands = { -- Format strings for git subcommands
       update         = '-C %s pull --ff-only --progress --rebase=false',
-      install        = 'clone %s %s --depth %i --no-single-branch --progress',
+      install        = 'clone --depth %i --no-single-branch --progress',
       fetch          = '-C %s fetch --depth 999999 --progress',
       checkout       = '-C %s checkout %s --',
       update_branch  = '-C %s merge --ff-only @{u}',

--- a/doc/packer.txt
+++ b/doc/packer.txt
@@ -199,7 +199,7 @@ default values: >
       cmd = 'git', -- The base command for git operations
       subcommands = { -- Format strings for git subcommands
         update         = '-C %s pull --ff-only --progress --rebase=false',
-        install        = 'clone %s %s --depth %i --no-single-branch --progress',
+        install        = 'clone --depth %i --no-single-branch --progress',
         fetch          = '-C %s fetch --depth 999999 --progress',
         checkout       = '-C %s checkout %s --',
         update_branch  = '-C %s merge --ff-only @{u}',

--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -24,7 +24,7 @@ local config_defaults = {
     cmd = 'git',
     subcommands = {
       update = '-C %s pull --ff-only --progress --rebase=false',
-      install = 'clone %s %s --depth %i --no-single-branch --progress',
+      install = 'clone --depth %i --no-single-branch --progress',
       fetch = '-C %s fetch --depth 999999 --progress',
       checkout = '-C %s checkout %s --',
       update_branch = '-C %s merge --ff-only @{u}',

--- a/lua/packer/clean.lua
+++ b/lua/packer/clean.lua
@@ -67,10 +67,9 @@ local clean_plugins = function(_, plugins, results)
       if await(display.ask_user('Removing the following directories. OK? (y/N)', lines)) then
         results.removals = dirty_plugins
         log.debug('Removed ' .. vim.inspect(dirty_plugins))
-        if util.is_windows then
-          for _, path in ipairs(dirty_plugins) do os.execute('cmd /C rmdir /S /Q ' .. path) end
-        else
-          os.execute('rm -rf ' .. table.concat(dirty_plugins, ' '))
+        for _, path in ipairs(dirty_plugins) do
+          local result = vim.fn.delete(path, 'rf')
+          if result == -1 then log.warn('Could not remove ' .. path) end
         end
       else
         log.warn('Cleaning cancelled!')

--- a/lua/packer/plugin_types/git.lua
+++ b/lua/packer/plugin_types/git.lua
@@ -83,9 +83,10 @@ end
 git.setup = function(plugin)
   local plugin_name = util.get_plugin_full_name(plugin)
   local install_to = plugin.install_path
-  local install_cmd = config.exec_cmd
-                        .. fmt(config.subcommands.install, plugin.url, install_to,
-                               plugin.commit and 999999 or config.depth)
+  local install_cmd = vim.split(config.exec_cmd
+                        .. fmt(config.subcommands.install,
+                               plugin.commit and 999999 or config.depth), '%s+')
+
   local submodule_cmd = config.exec_cmd .. fmt(config.subcommands.submodules, install_to)
   local rev_cmd = config.exec_cmd .. fmt(config.subcommands.get_rev, install_to)
   local update_cmd = config.exec_cmd
@@ -108,8 +109,12 @@ git.setup = function(plugin)
   end
 
   if plugin.branch or plugin.tag then
-    install_cmd = fmt('%s --branch %s', install_cmd, plugin.branch and plugin.branch or plugin.tag)
+    table.insert(install_cmd, '--branch')
+    table.insert(install_cmd, plugin.branch and plugin.branch or plugin.tag)
   end
+
+  table.insert(install_cmd, plugin.url)
+  table.insert(install_cmd, install_to)
 
   local needs_checkout = plugin.tag ~= nil or plugin.commit ~= nil or plugin.branch ~= nil
 

--- a/lua/packer/plugin_types/git.lua
+++ b/lua/packer/plugin_types/git.lua
@@ -109,12 +109,12 @@ git.setup = function(plugin)
   end
 
   if plugin.branch or plugin.tag then
-    table.insert(install_cmd, '--branch')
-    table.insert(install_cmd, plugin.branch and plugin.branch or plugin.tag)
+    install_cmd[#install_cmd + 1] = '--branch'
+    install_cmd[#install_cmd + 1] = plugin.branch and plugin.branch or plugin.tag
   end
 
-  table.insert(install_cmd, plugin.url)
-  table.insert(install_cmd, install_to)
+  install_cmd[#install_cmd + 1] = plugin.url
+  install_cmd[#install_cmd + 1] = install_to
 
   local needs_checkout = plugin.tag ~= nil or plugin.commit ~= nil or plugin.branch ~= nil
 


### PR DESCRIPTION
This PR:
- changes the default `git.install` command and how `git.setup()` handles URLs/paths for that command
- uses `vim.fn.delete()` to remove dirty plugins instead of `os.execute()` (as a bonus, this removes the last reference to `is_windows` outside of `util.lua`)

Together with #303, this should address #165 and #287.

The issue with the current approach is that `run_job()` [uses whitespace to split strings](https://github.com/wbthomason/packer.nvim/blob/b76bfba54031ad28f17e98ef555e99cf450d6cb3/lua/packer/jobs.lua#L173-L176), which means any path that contains whitespace will make the command fail.

This PR changes the API so that `git.install` can be split early before inserting the paths in the newly created table with `table.insert()`