### PR TITLE
ci: add workflow for stylua formatting

### DIFF
--- a/.github/workflows/formatting.yaml
+++ b/.github/workflows/formatting.yaml
@@ -1,0 +1,29 @@
+name: formatting
+on:
+  push:
+    paths-ignore:
+      - ".github/**"
+      - "*.md"
+    branches: ["master"]
+
+jobs:
+  stylua:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: JohnnyMorganz/stylua-action@1.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --config-path=stylua.toml lua/
+      - name: Commit files
+        run: |
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          if ! [[ -z $(git status -s) ]]; then
+            git commit -m "format lua" lua/*
+          fi
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.ref }}


### PR DESCRIPTION
@wbthomason this adds a github workflow for stylua.

A few things to note:
* It's currently set to format whenever anything is added to the `master` branch, I had t this way on my projects just to make sure nothing got missed, but it could alternatively be on PRs.
* The author of the formatting commit is the github bot, I've done it this way as I just saw a bunch of examples and copied them, I personally don't care much, but it could be changed
* I've ignored doc files like `.md`

I haven't actually formatted the repo as part of this change