### PR TITLE
fix(compile): blank `packer_compile` error messages

### DIFF
--- a/lua/packer/compile.lua
+++ b/lua/packer/compile.lua
@@ -30,7 +30,7 @@ end
 
 vim.api.nvim_command('packadd packer.nvim')
 
-local no_errors = pcall(function()
+local no_errors, error_msg = pcall(function()
 ]]
 
 local catch_errors = [[
@@ -46,7 +46,7 @@ local catch_errors_lua = [[
 end)
 
 if not no_errors then
-  vim.api.nvim_command('echohl ErrorMsg | echom "Error in packer_compiled: ".v:exception | echom "Please check your config for correctness" | echohl None')
+  vim.api.nvim_command('echohl ErrorMsg | echom "Error in packer_compiled: '..error_msg..'" | echom "Please check your config for correctness" | echohl None')
 end
 ]]
 


### PR DESCRIPTION
After the recent PR, error messages occurring in the `packer_compiled.lua` file (such as in configs, or plugins) were left blank. This was my bad— `pcall()` raises its own errors, and they don't interfere with `v:exception`.