### PR TITLE
Use CmdUndefined autocommand for lazy loading on commands.

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ use {
   -- The setup key implies opt = true
   setup = string or function,  -- Specifies code to run before this plugin is loaded.
   -- The following keys all imply lazy-loading and imply opt = true
-  cmd = string or list,        -- Specifies commands which load this plugin.
+  cmd = string or list,        -- Specifies commands which load this plugin. Can have patterns.
   ft = string or list,         -- Specifies filetypes which load this plugin.
   keys = string or list,       -- Specifies maps which load this plugin. See "Keybindings".
   event = string or list,      -- Specifies autocommand events which load this plugin.
@@ -382,6 +382,10 @@ use {
   requiring a string which matches one of these patterns, the plugin will be loaded.
 }
 ```
+
+For the `cmd` option, the command may be a full command, or an autocommand pattern. If the command contains any
+non-alphanumeric characters, it is assumed to be a pattern, and instead of creating a stub command, it creates
+a CmdUndefined autocmd to load the plugin when a command that matches the pattern is invoked.
 
 #### Checking plugin statuses
 You can check whether or not a particular plugin is installed with `packer` as well as if that plugin is loaded.

--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ use {
   -- The setup key implies opt = true
   setup = string or function,  -- Specifies code to run before this plugin is loaded.
   -- The following keys all imply lazy-loading and imply opt = true
-  cmd = string or list,        -- Specifies commands which load this plugin. Can have patterns.
+  cmd = string or list,        -- Specifies commands which load this plugin. Can be an autocmd pattern.
   ft = string or list,         -- Specifies filetypes which load this plugin.
   keys = string or list,       -- Specifies maps which load this plugin. See "Keybindings".
   event = string or list,      -- Specifies autocommand events which load this plugin.

--- a/doc/packer.txt
+++ b/doc/packer.txt
@@ -555,7 +555,7 @@ invoked as follows:
     config = string or function, -- Specifies code to run after this plugin is loaded.
     rocks = string or list,      -- Specifies Luarocks dependencies for the plugin
     -- The following keys all imply lazy-loading
-    cmd = string or list,        -- Specifies commands which load this plugin.  Can be autocmd pattern.
+    cmd = string or list,        -- Specifies commands which load this plugin.  Can be an autocmd pattern.
     ft = string or list,         -- Specifies filetypes which load this plugin.
     keys = string or list,       -- Specifies maps which load this plugin. See |packer-plugin-keybindings|
     event = string or list,      -- Specifies autocommand events which load this plugin.

--- a/doc/packer.txt
+++ b/doc/packer.txt
@@ -555,7 +555,7 @@ invoked as follows:
     config = string or function, -- Specifies code to run after this plugin is loaded.
     rocks = string or list,      -- Specifies Luarocks dependencies for the plugin
     -- The following keys all imply lazy-loading
-    cmd = string or list,        -- Specifies commands which load this plugin.
+    cmd = string or list,        -- Specifies commands which load this plugin.  Can be autocmd pattern.
     ft = string or list,         -- Specifies filetypes which load this plugin.
     keys = string or list,       -- Specifies maps which load this plugin. See |packer-plugin-keybindings|
     event = string or list,      -- Specifies autocommand events which load this plugin.
@@ -568,5 +568,9 @@ invoked as follows:
                                  -- which matches one of these patterns, the plugin will be loaded.
   }
 - With a list of plugins specified in either of the above two forms
+
+For the *cmd* option, the command may be a full command, or an autocommand pattern. If the command contains any
+non-alphanumeric characters, it is assumed to be a pattern, and instead of creating a stub command, it creates
+a CmdUndefined autocmd to load the plugin when a command that matches the pattern is invoked.
 
  vim:tw=78:ts=2:ft=help:norl:

--- a/lua/packer/compile.lua
+++ b/lua/packer/compile.lua
@@ -550,12 +550,21 @@ local function make_loaders(_, plugins, output_lua, should_profile)
 
   local command_defs = {}
   for command, names in pairs(commands) do
-    local command_line = fmt(
-      'pcall(vim.cmd, [[command -nargs=* -range -bang -complete=file %s lua require("packer.load")({%s}, { cmd = "%s", l1 = <line1>, l2 = <line2>, bang = <q-bang>, args = <q-args> }, _G.packer_plugins)]])',
-      command,
-      table.concat(names, ', '),
-      command
-    )
+    local command_line
+    if string.match(command, "^%w+$") then
+      command_line = fmt(
+        'pcall(vim.cmd, [[command! -nargs=* -range -bang -complete=file %s lua require("packer.load")({%s}, { cmd = "%s", l1 = <line1>, l2 = <line2>, bang = <q-bang>, args = <q-args> }, _G.packer_plugins)]])',
+        command,
+        table.concat(names, ', '),
+        command
+      )
+    else
+      command_line = fmt(
+        'pcall(vim.cmd, [[au CmdUndefined %s ++once lua require"packer.load"({%s}, {}, _G.packer_plugins)]])',
+        command,
+        table.concat(names, ', ')
+      )
+    end
     command_defs[#command_defs + 1] = command_line
   end
 


### PR DESCRIPTION
Fixes #408

The downside to this is that command autocompletion no longer works.

Potentially the old way could be a seperate option?