### PR TITLE
Allow top level and required plugin usages

### DIFF
--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -187,7 +187,7 @@ manage = function(plugin_data)
     return
   end
 
-  if plugins[name] then
+  if plugins[name] and not plugins[name].from_requires then
     log.warn('Plugin "' .. name .. '" is used twice! (line ' .. spec_line .. ')')
     return
   end
@@ -257,6 +257,11 @@ manage = function(plugin_data)
       end
       local req_name_segments = vim.split(req[1], '/')
       local req_name = req_name_segments[#req_name_segments]
+      -- this flag marks a plugin as being from a require which we use to allow
+      -- multiple requires for a plugin without triggering a duplicate warning *IF*
+      -- the plugin is from a `requires` field and the full specificaiton has not been called yet.
+      -- @see: https://github.com/wbthomason/packer.nvim/issues/258#issuecomment-876568439
+      req.from_requires = true
       if not plugins[req_name] then
         if config.transitive_opt and plugin_spec.manual_opt then
           req.opt = true


### PR DESCRIPTION
This fixes an issue where if a top level spec for a plugin was called
after a required spec for that, a duplicate error was shown.
e.g.
```lua
use {'first/plugin', requires = {'another/plugin'}}
use 'another/plugin' -- <- This would throw a duplicate plugin error
```

This PR instead adds a flag to ignore the duplicate warning if the initial
plugin spec was from a `require`.

This is based off of https://github.com/wbthomason/packer.nvim/issues/258#issuecomment-876568439.