### PR TITLE
Fix #469: Avoid re-running module loaders for lazy-loaded modules

### DIFF
--- a/lua/packer/compile.lua
+++ b/lua/packer/compile.lua
@@ -138,8 +138,9 @@ local function lazy_load_module(module_name)
 
   if #to_load > 0 then
     require('packer.load')(to_load, {module = module_name}, _G.packer_plugins)
-    if package.loaded[module_name] then
-      return function(modname) return package.loaded[modname] end
+    local loaded_mod = package.loaded[module_name]
+    if loaded_mod then
+      return function(modname) return loaded_mod end
     end
   end
 end

--- a/lua/packer/compile.lua
+++ b/lua/packer/compile.lua
@@ -131,12 +131,17 @@ local function lazy_load_module(module_name)
   if lazy_load_called[module_name] then return nil end
   lazy_load_called[module_name] = true
   for module_pat, plugin_name in pairs(module_lazy_loads) do
-    if not _G.packer_plugins[plugin_name].loaded and string.match(module_name, module_pat)then
+    if not _G.packer_plugins[plugin_name].loaded and string.match(module_name, module_pat) then
       to_load[#to_load + 1] = plugin_name
     end
   end
 
-  require('packer.load')(to_load, {module = module_name}, _G.packer_plugins)
+  if #to_load > 0 then
+    require('packer.load')(to_load, {module = module_name}, _G.packer_plugins)
+    if package.loaded[module_name] then
+      return function(modname) return package.loaded[modname] end
+    end
+  end
 end
 
 if not vim.g.packer_custom_loader_enabled then


### PR DESCRIPTION
This was a fun one! #469 was caused because the `module` lazy-loader had the following control flow:
1. Call `packer.load` for the plugins that needed to be loaded
2. In `packer.load`, run any `config` key functions, **which may require the lazy-loaded module**
3. Return `nil`, to pass on the loading process to a subsequent module loader

The problem is that, in step 2, the lazy-loader may get recursively invoked but (correctly) skip to step 3, actually loading the module. Then, by doing step 3 **again** in the original invocation, we basically force the package.path/other loader to run again, re-loading the module.

This commit fixes the issue by instead returning the **already loaded** module from `package.loaded`, if indeed this value exists.

Closes #469