### PR TITLE
fix(compile): should check command strictly

### DIFF
--- a/lua/packer/compile.lua
+++ b/lua/packer/compile.lua
@@ -263,7 +263,7 @@ local function generate_checked_command(command_name, plugin_names)
     table.concat(plugin_names, ', '),
     command_name
   )
-  return { fmt('if vim.fn.exists(":%s") == 0 then', command_name), command_creation, 'end' }
+  return { fmt('if vim.fn.exists(":%s") ~= 2 then', command_name), command_creation, 'end' }
 end
 
 local function make_loaders(_, plugins, output_lua, should_profile)


### PR DESCRIPTION
vim.fn.exist(':Bar') return 1 if `BarBar` has defined, should use full match instead

The below snippet is produced by packer.nvim, and I add some comments for debugging.
```lua
-- Command lazy-loads
time([[Defining lazy-load commands]], true)
if vim.fn.exists(":GitMessenger") == 0 then
vim.cmd [[command! -nargs=* -range -bang -complete=file GitMessenger lua require("packer.load")({'git-messenger.vim'}, { cmd = "GitMessenger", l1 = <line1>, l2 = <line2>, bang = <q-bang>, args = <q-args> }, _G.packer_plugins)]]
end
-- add by kevin
-- print('exists? :', vim.fn.exists(":Git"))
if vim.fn.exists(":Git") == 0 then
vim.cmd [[command! -nargs=* -range -bang -complete=file Git lua require("packer.load")({'vim-fugitive'}, { cmd = "Git", l1 = <line1>, l2 = <line2>, bang = <q-bang>, args = <q-args> }, _G.packer_plugins)]]
end
-- add by kevin
-- vim.schedule(function()
--     vim.cmd('verb command Git')
-- end)
time([[Defining lazy-load keymaps]], false)

```