### PR TITLE
Feature: check that a plugin is actually installed before running its config

### DIFF
--- a/lua/packer/load.lua
+++ b/lua/packer/load.lua
@@ -45,12 +45,20 @@ packer_load = function(names, cause, plugins)
       end
 
       if plugin.config then
-        for _, config_line in ipairs(plugin.config) do
-          local success, err = pcall(loadstring(config_line))
-          if not success then
-            print('Error running config for ' .. names[i])
-            error(err)
+        if vim.loop.fs_lstat(plugin.path) ~= nil then
+          for _, config_line in ipairs(plugin.config) do
+            local success, err = pcall(loadstring(config_line))
+            if not success then
+              print('Error running config for ' .. names[i])
+              error(err)
+            end
           end
+        else
+          vim.api.nvim_notify(
+            'packer.nvim: Skipping config for ' .. names[i] .. ' because plugin is not installed!',
+            vim.log.levels.WARN,
+            {}
+          )
         end
       end
 


### PR DESCRIPTION
This addresses the concern raised by @florentc in #506 by asynchronously checking that a plugin's install path actually exists before we run its `config` function. Note that we still run `setup` functions as usual because they are designed to run before a plugin is loaded anyway, so they should be fine to run before a plugin is installed. Making this choice helps us avoid needing to think about some race conditions which could otherwise arise.

@florentc: Can you please confirm that this behaves as expected? @akinsho if you have a chance to look at this, that would also be great, but nw if you're busy - it's a fairly simple change.