### PR TITLE
Add the module_pattern key

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,8 @@ use {
   cond = string, function, or list of strings/functions,   -- Specifies a conditional test to load this plugin
   module = string or list      -- Specifies Lua module names for require. When requiring a string which starts
                                -- with one of these module names, the plugin will be loaded.
+  module_pattern = string/list -- Specifies Lua pattern of Lua module names for require. When
+  requiring a string which matches one of these patterns, the plugin will be loaded.
 }
 ```
 

--- a/doc/packer.txt
+++ b/doc/packer.txt
@@ -562,9 +562,8 @@ invoked as follows:
     setup = string or function,  -- Specifies code to run before this plugin is loaded.
     module = string or list      -- Specifies Lua module names for require. When requiring a string which starts
                                  -- with one of these module names, the plugin will be loaded.
-  module_pattern = string/list   -- Specifies Lua pattern of Lua module names for
-  require. When requiring a string which matches one of these patterns, the
-  plugin will be loaded.
+    module_pattern = string/list -- Specifies Lua pattern of Lua module names for require. When requiring a string
+                                 -- which matches one of these patterns, the plugin will be loaded.
   }
 - With a list of plugins specified in either of the above two forms
 

--- a/doc/packer.txt
+++ b/doc/packer.txt
@@ -562,6 +562,9 @@ invoked as follows:
     setup = string or function,  -- Specifies code to run before this plugin is loaded.
     module = string or list      -- Specifies Lua module names for require. When requiring a string which starts
                                  -- with one of these module names, the plugin will be loaded.
+  module_pattern = string/list   -- Specifies Lua pattern of Lua module names for
+  require. When requiring a string which matches one of these patterns, the
+  plugin will be loaded.
   }
 - With a list of plugins specified in either of the above two forms
 

--- a/lua/packer/compile.lua
+++ b/lua/packer/compile.lua
@@ -439,14 +439,26 @@ local function make_loaders(_, plugins, output_lua, should_profile)
         end
       end
 
-      if plugin.module then
+      if plugin.module or plugin.module_pattern then
         loaders[name].only_sequence = false
         loaders[name].only_setup = false
-        if type(plugin.module) == 'string' then
-          plugin.module = { plugin.module }
-        end
-        for _, module_name in ipairs(plugin.module) do
-          module_lazy_loads['^' .. vim.pesc(module_name)] = name
+
+        if plugin.module then
+          if type(plugin.module) == 'string' then
+            plugin.module = { plugin.module }
+          end
+
+          for _, module_name in ipairs(plugin.module) do
+            module_lazy_loads['^' .. vim.pesc(module_name)] = name
+          end
+        else
+          if type(plugin.module_pattern) == 'string' then
+            plugin.module_pattern = { plugin.module_pattern }
+          end
+
+          for _, module_pattern in ipairs(plugin.module_pattern) do
+            module_lazy_loads[module_pattern] = name
+          end
         end
       end
 

--- a/lua/packer/compile.lua
+++ b/lua/packer/compile.lua
@@ -777,6 +777,6 @@ end
 
 local compile = setmetatable({ cfg = cfg }, { __call = make_loaders })
 
-compile.opt_keys = { 'after', 'cmd', 'ft', 'keys', 'event', 'cond', 'setup', 'fn', 'module' }
+compile.opt_keys = { 'after', 'cmd', 'ft', 'keys', 'event', 'cond', 'setup', 'fn', 'module', 'module_pattern' }
 
 return compile


### PR DESCRIPTION
Closes #478 by adding a new key, `module_pattern`, which works exactly the same as `module` but does not run `pesc` or prepend a caret to the pattern.

@thezealousfool: Can you please confirm that this does what you wanted in #478?
@akinsho: If you have a chance to try this out, that would be great, but as always nw if you don't have time, etc.