### PR TITLE
Add feat to expose get_bin_path API

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,28 @@ return require('packer').startup(function()
     rocks = {'lpeg', {'lua-cjson', version = '2.1.0'}}
   }
 
+  -- Plugint can get path to rocks binaries
+  use {
+    'mhartington/formatter.nvim',
+    rocks = {'luaformatter', server = 'https://luarocks.org/dev'},
+    config = function()
+      local rockbin = require('packer.luarocks').get_bin_path()
+      local util = require('packer.util')
+      local luaformat = util.join_paths(rockbin, 'lua-format')
+
+      require("formatter").setup({
+        logging = false,
+        filetype = {
+          lua = {
+            function()
+              return {exe = luaformat, args = {}, stdin = true}
+            end
+          }
+        }
+      })
+    end,
+  }
+
   -- You can specify rocks in isolation
   use_rocks 'penlight'
   use_rocks {'lua-resty-http', 'lpeg'}
@@ -391,6 +413,8 @@ Entries in the list may either be strings, a list of strings or a table --- the 
 particular version of a package.
 all supported luarocks keys are allowed except: `tree` and `local`. Environment variables for the luarocks command can also be
 specified using the `env` key which takes a table as the value as shown below.
+Luarocks binaries path can be accessed by `packer.luarocks.get_bin_path`
+
 ```lua
 rocks = {'lpeg', {'lua-cjson', version = '2.1.0'}}
 use_rocks {'lua-cjson', 'lua-resty-http'}

--- a/lua/packer/luarocks.lua
+++ b/lua/packer/luarocks.lua
@@ -33,6 +33,7 @@ else
     clean = warn_need_luajit,
     install = warn_need_luajit,
     ensure = warn_need_luajit,
+	get_bin_path = warn_need_luajit,
     generate_path_setup = function()
       return ''
     end,
@@ -566,6 +567,14 @@ local function make_commands()
   vim.cmd [[ command! -nargs=+ PackerRocks lua require('packer.luarocks').handle_command(<f-args>) ]]
 end
 
+--[[
+-- Returns the path to bin of the hererocks installation
+-- @returns { string } absolute directory path to hererocks bin
+--]]
+local function get_bin_path()
+  return util.join_paths(hererocks_install_dir, 'bin')
+end
+
 return {
   handle_command = handle_command,
   install_commands = make_commands,
@@ -577,5 +586,6 @@ return {
   install = install_sync,
   ensure = ensure_rocks,
   generate_path_setup = generate_path_setup_code,
+  get_bin_path = get_bin_path,
   cfg = cfg,
 }


### PR DESCRIPTION
Packages like `mhartington/formatter.nvim` may depend on executable files installed through `luarocks`. At the moment there is no any API to get the `hererocks/bin` path. This exposes `packer.luarocks.get_bin_path()` API that returns the absolute path to bin.