### PR TITLE
Ensure rocks even if there are no plugins to install

### DIFF
--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -384,25 +384,28 @@ packer.install = function(...)
     if not install_plugins then
       install_plugins = vim.tbl_keys(fs_state.missing)
     end
-    if #install_plugins == 0 then
-      log.info 'All configured plugins are installed'
-      packer.on_complete()
-      return
-    end
 
     await(a.main)
     local start_time = vim.fn.reltime()
     local results = {}
     await(clean(plugins, fs_state, results))
+
+    if #install_plugins == 0 and #rocks == 0 then
+      log.info 'All configured plugins and rocks are installed'
+      packer.on_complete()
+      return
+    end
+
     await(a.main)
     log.debug 'Gathering install tasks'
     local tasks, display_win = install(plugins, install_plugins, results)
+    log.debug 'Gathering Luarocks tasks'
+    local luarocks_ensure_task = luarocks.ensure(rocks, results, display_win)
+    if luarocks_ensure_task ~= nil then
+      table.insert(tasks, luarocks_ensure_task)
+    end
+
     if next(tasks) then
-      log.debug 'Gathering Luarocks tasks'
-      local luarocks_ensure_task = luarocks.ensure(rocks, results, display_win)
-      if luarocks_ensure_task ~= nil then
-        table.insert(tasks, luarocks_ensure_task)
-      end
       table.insert(tasks, 1, function()
         return not display.status.running
       end)

--- a/lua/packer/luarocks.lua
+++ b/lua/packer/luarocks.lua
@@ -1,6 +1,7 @@
 -- Add support for installing and cleaning Luarocks dependencies
 -- Based off of plenary/neorocks/init.lua in https://github.com/nvim-lua/plenary.nvim
 local a = require 'packer.async'
+local display = require 'packer.display'
 local jobs = require 'packer.jobs'
 local log = require 'packer.log'
 local result = require 'packer.result'
@@ -496,9 +497,15 @@ local function ensure_rocks(rocks, results, disp)
     if next(to_install) == nil then
       return r
     end
+
     if not hererocks_is_setup() then
+      if disp == nil then
+        disp = display.open(config.display.open_fn or config.display.open_cmd)
+      end
+
       r = r:and_then(await, hererocks_installer(disp))
     end
+
     r:and_then(await, luarocks_list(disp))
     r:map_ok(function(installed_packages)
       for _, package in ipairs(installed_packages) do


### PR DESCRIPTION
Closes #524 by always checking if we need to ensure the installation of any rocks.

@nanotee I have not tested this at all yet, but I think this is (modulo some small bugfixes) what needs to happen to fix #524.