### PR TITLE
feat(keys) adds function so easier specify many key combinations

### DIFF
--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -1,6 +1,7 @@
 -- TODO: Performance analysis/tuning
 -- TODO: Merge start plugins?
 local util = require 'packer.util'
+local keys = require 'packer.keys'
 
 local join_paths = util.join_paths
 local stdpath = vim.fn.stdpath
@@ -822,5 +823,7 @@ packer.startup = function(spec)
 
   return packer
 end
+
+packer.get_keys = keys.get_keys
 
 return packer

--- a/lua/packer/keys.lua
+++ b/lua/packer/keys.lua
@@ -1,0 +1,47 @@
+local M = {}
+
+local function string_product(keys)
+    if #keys == 1 then
+        return keys[1]
+    end
+    local keys_copy = {}
+    for _, key in ipairs(keys) do
+        table.insert(keys_copy, key)
+    end
+    local product = {}
+    local first = table.remove(keys_copy, 1)
+    for _, a in ipairs(first) do
+        if type(a) ~= 'string' then
+            vim.cmd('echoerr "Not a valid keys table"')
+        end
+        for _, b in ipairs(string_product(keys_copy)) do
+            table.insert(product, a .. b)
+        end
+    end
+    return product
+end
+
+local function expand_keys(keys)
+    if type(keys) == 'string' then
+        return {keys}
+    elseif type(keys[1]) == 'string' then
+        return keys
+    else
+        return string_product(keys)
+    end
+end
+
+M.get_keys = function(modes, keys)
+    if type(modes) == 'string' then
+        modes = {modes}
+    end
+    local combinations = {}
+    for _, mode in ipairs(modes) do
+        for _, v in ipairs(expand_keys(keys)) do
+            table.insert(combinations, {mode, v})
+        end
+    end
+    return combinations
+end
+
+return M


### PR DESCRIPTION
I wrote some utility function to make it easier to specify many key combinations and thought I would share it here if you find it useful.

Previously for example I wrote:
```lua
use {
    'michaeljsmith/vim-indent-object',
    keys = {
        {'o', 'ii'},
        {'o', 'ai'},
        {'o', 'iI'},
        {'o', 'aI'},
        {'v', 'ii'},
        {'v', 'ai'},
        {'v', 'iI'},
        {'v', 'aI'},
    },
    wants = 'vim-textobj-user',
}
```
but with this I can write:
```lua
use {
    'michaeljsmith/vim-indent-object',
    keys = get_keys({'o', 'v'}, {{'a', 'i'}, {'i', 'I'}}),
    wants = 'vim-textobj-user',
}
```
which expands to the product of the individual keys in the specified modes.

Some examples:
```lua
local get_keys = require('packer').get_keys
print(vim.inspect(get_keys('n', 'a')))
print(vim.inspect(get_keys('n', {'a', 'b'})))
print(vim.inspect(get_keys('n', {{'a', 'b'}, {'c', 'd'}})))
print(vim.inspect(get_keys({'n', 'o'}, {{'a', 'b'}, {'c', 'd'}})))
```
which gives
```
{ { "n", "a" } }
{ { "n", "a" }, { "n", "b" } }
{ { "n", "ac" }, { "n", "ad" }, { "n", "bc" }, { "n", "bd" } }
{ { "n", "ac" }, { "n", "ad" }, { "n", "bc" }, { "n", "bd" }, { "o", "ac" }, { "o", "ad" }, { "o", "bc" }, { "o", "bd" } }
```

I considered trying to have some way to automatically parse these structures so that one does not need to even do the function call but not sure it's possible/worth it.
