### PR TITLE
Fix #551: failing to run command post hooks on Windows

### DIFF
--- a/lua/packer/plugin_utils.lua
+++ b/lua/packer/plugin_utils.lua
@@ -240,7 +240,13 @@ plugin_utils.post_update_hook = function(plugin, disp)
               stderr = jobs.logging_callback(hook_output.err, hook_output.output, nil, disp, plugin_name),
               stdout = jobs.logging_callback(hook_output.err, hook_output.output, nil, disp, plugin_name),
             }
-            local cmd = { os.getenv 'SHELL' or vim.o.shell, '-c', task }
+            local cmd
+            local shell = os.getenv 'SHELL' or vim.o.shell
+            if shell:find('cmd.exe$') then
+                cmd = { shell, '/c', task }
+            else
+                cmd = { shell, '-c', task }
+            end
             return await(jobs.run(cmd, { capture_output = hook_callbacks, cwd = plugin.install_path })):map_err(
               function(err)
                 return {


### PR DESCRIPTION
Fix #551 

The default value of `vim.o.shell` on Windows is `cmd.exe` or `C:\WINDOWS\system32\cmd.exe`, and `cmd` shell rejects the parameter `-c`, use `/c` instead when the shell is `cmd`.

By the way, you can not just check the OS since the `powershell` on Windows should use `-c` parameter.