### PR TITLE
Wrap the example PackerCompile autocmd in an augroup

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ You can configure Neovim to automatically run `:PackerCompile` whenever `plugins
 [an autocommand](https://neovim.io/doc/user/autocmd.html#:autocmd):
 
 ```
-augroup packer
+augroup packer_user_config
   autocmd!
   autocmd BufWritePost plugins.lua source <afile> | PackerCompile
 augroup end
@@ -214,7 +214,7 @@ Placing this in `plugins.lua` could look like this:
 
 ```lua
 vim.cmd([[
-  augroup packer
+  augroup packer_user_config
     autocmd!
     autocmd BufWritePost plugins.lua source <afile> | PackerCompile
   augroup end

--- a/README.md
+++ b/README.md
@@ -199,17 +199,26 @@ end)
 :PackerLoad completion-nvim ale
 ```
 
-You can configure Neovim to automatically run `:PackerCompile` whenever `plugins.lua` is updated with an autocommand:
+You can configure Neovim to automatically run `:PackerCompile` whenever `plugins.lua` is updated with
+[an autocommand](https://neovim.io/doc/user/autocmd.html#:autocmd):
 
 ```
-autocmd BufWritePost plugins.lua source <afile> | PackerCompile
+augroup packer
+  autocmd!
+  autocmd BufWritePost plugins.lua source <afile> | PackerCompile
+augroup end
 ```
 
 This autocommand can be placed in your `init.vim`, or any other startup file as per your setup.
 Placing this in `plugins.lua` could look like this:
 
 ```lua
-vim.cmd([[autocmd BufWritePost plugins.lua source <afile> | PackerCompile]])
+vim.cmd([[
+  augroup packer
+    autocmd!
+    autocmd BufWritePost plugins.lua source <afile> | PackerCompile
+  augroup end
+]])
 ```
 
 ## Bootstrapping


### PR DESCRIPTION
Applying the earlier example verbatim without thinking about it would lead to the autocommand being re-created each time plugins.lua was reloaded, and could make PackerCompile "feel slow" because it was run multiple times.