### PR TITLE
Fix: Fetch before checkout on git update

### DIFF
--- a/lua/packer/plugin_types/git.lua
+++ b/lua/packer/plugin_types/git.lua
@@ -302,7 +302,19 @@ git.setup = function(plugin)
         end
       end
 
+      local update_callbacks = {
+        stdout = jobs.logging_callback(update_info.err, update_info.output),
+        stderr = jobs.logging_callback(update_info.err, update_info.output, nil, disp, plugin_name),
+      }
+      local update_opts = {
+        success_test = exit_ok,
+        capture_output = update_callbacks,
+        cwd = install_to,
+        options = { env = git.job_env },
+      }
+
       if needs_checkout then
+        r:and_then(await, jobs.run(config.exec_cmd .. config.subcommands.fetch, update_opts))
         r:and_then(await, handle_checkouts(plugin, install_to, disp))
         local function merge_output(res)
           if res.output ~= nil then
@@ -321,18 +333,7 @@ git.setup = function(plugin)
         end)
       end
 
-      local update_callbacks = {
-        stdout = jobs.logging_callback(update_info.err, update_info.output),
-        stderr = jobs.logging_callback(update_info.err, update_info.output, nil, disp, plugin_name),
-      }
-
       disp:task_update(plugin_name, 'pulling updates...')
-      local update_opts = {
-        success_test = exit_ok,
-        capture_output = update_callbacks,
-        cwd = install_to,
-        options = { env = git.job_env },
-      }
 
       r
         :and_then(await, jobs.run(update_cmd, update_opts))


### PR DESCRIPTION
Fixes #558 by adding a fetch before handling checkouts for git plugin updates. In my testing, this allowed switching between specific (and previously unused) branches and commits, as well as the "default" HEAD specification.

@stasjok @JoseConseco can you please confirm that this fixes the issue for you?
