### PR TITLE
fix: plugins loaded with cond not marked as loaded

### DIFF
--- a/lua/packer/compile.lua
+++ b/lua/packer/compile.lua
@@ -526,7 +526,8 @@ local function make_loaders(_, plugins, output_lua, should_profile)
   for condition, names in pairs(condition_ids) do
     local conditional_loads = {}
     for _, name in ipairs(names) do
-      timed_chunk('\tvim.cmd [[packadd ' .. name .. ']]', 'packadd for ' .. name, conditional_loads)
+      timed_chunk({'\tvim.cmd [[packadd ' .. name .. ']]',
+                   '\t_G.packer_plugins["'..name..'"].loaded = true'}, 'packadd for ' .. name, conditional_loads)
       if plugins[name].config then
         local lines = { '-- Config for: ' .. name }
         timed_chunk(plugins[name].executable_config, 'Config for ' .. name, lines)


### PR DESCRIPTION
Currently plugins loaded with `cond` shows as not loaded in `PackerStatus`. This fixes that issue by marking them loaded.

TBH I'm not sure why it's directly loading with `:packadd` instead of calling loader from packer/load .

@wbthomason Is there a reason why it's like that ? Using single loader sounds like a better idea and that'll also solve this issue .