### PR TITLE
enhance: sort lines in PackerStatus

### DIFF
--- a/lua/packer/display.lua
+++ b/lua/packer/display.lua
@@ -378,6 +378,7 @@ local display_mt = {
       end
       vim.list_extend(lines, header_lines)
     end
+    table.sort(lines)
     self.items = plugs
     self:set_lines(config.header_lines, -1, lines)
   end),


### PR DESCRIPTION
Plugins appearing at random positions in `PackerStatus` is just annoying