### PR TITLE
fix(compile) schedule loading to after event

### DIFF
--- a/lua/packer/compile.lua
+++ b/lua/packer/compile.lua
@@ -487,7 +487,7 @@ local function make_loaders(_, plugins, output_lua, should_profile)
     table.insert(
       event_aucmds,
       fmt(
-        'vim.cmd [[au %s ++once lua require("packer.load")({%s}, { event = "%s" }, _G.packer_plugins)]]',
+        'vim.cmd [[au %s ++once lua vim.schedule(function() require("packer.load")({%s}, { event = "%s" }, _G.packer_plugins) end)]]',
         event,
         table.concat(names, ', '),
         event:gsub([[\]], [[\\]])


### PR DESCRIPTION
As reported in https://github.com/AckslD/nvim-neoclip.lua/issues/26 it seems that autocommands defined in `config` are called twice if plugin is loaded by an `event`. To reproduce one can try the following small example:
```lua
    use {
        '~/some_path',
        event = 'TextYankPost',
        config = function()
            local count = 0
            _G.test_handler = function()
                count = count + 1
                print('called', count, 'times')
            end
            vim.cmd([[autocmd TextYankPost * lua _G.test_handler()]])
        end,
    }
```
(where `~/some_path` is some existing path)

If you compile this and yank something you will see `called 2 times`. Unless I'm mistaken this happens since the package (and `config`) is loaded while handling the event so the autocommand will be added and still executed. But also `doautocmd` is called which triggers the handler again.

This PR puts the loading in `vim.schedule` and will thus be handled after the event is "finished".