### PR TITLE
Update CI to test against 0.5.0 as well as current Neovim HEAD

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -65,7 +65,6 @@ jobs:
 
       - name: Run tests
         run: |
-          ls neovim
-          export PATH="neovim/bin:${PATH}"
-          export VIM="neovim/share/nvim/runtime"
+          export PATH="neovim/build/bin:${PATH}"
+          export VIM="neovim/build/share/nvim/runtime"
           nvim --headless --noplugin -u tests/minimal.vim -c "PlenaryBustedDirectory tests/ {minimal_init = 'tests/minimal.vim'}"


### PR DESCRIPTION
Updates the CI spec slightly to
1. Test against Neovim v0.5.0 as well as current HEAD
2. Build Neovim locally (hopefully fixing the issues we've had with downloading the nightly build)

Based largely off of @lewis6991's `gitsigns` CI setup. May be considered WIP until the tests run as expected.