### PR TITLE
fix(load): handle nil mods properly

### DIFF
--- a/lua/packer/load.lua
+++ b/lua/packer/load.lua
@@ -79,7 +79,7 @@ packer_load = function(names, cause, plugins)
   end
   if cause.cmd then
     local lines = cause.l1 == cause.l2 and '' or (cause.l1 .. ',' .. cause.l2)
-    vim.cmd(fmt('%s %s%s%s %s', cause.mods, lines, cause.cmd, cause.bang, cause.args))
+    vim.cmd(fmt('%s %s%s%s %s', cause.mods or '', lines, cause.cmd, cause.bang, cause.args))
   elseif cause.keys then
     local extra = ''
     while true do


### PR DESCRIPTION
I hadn't update my packer in quite a while but after doing so I had some issues, for example when running a command that is set to lazy load a package I got the error:
```
no such command: nil Command
```
(or something like that)
which seems to be caused by `cause.mods` being `nil`. This change just replaces it with `''` in that case.