### PR TITLE
Feature: add packer.use_with_context

### DIFF
--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -309,8 +309,12 @@ packer.use = function(plugin_spec)
   }
 end
 
-packer.use_with_context = function(ctx, plugin_specs)
-  for _, plugin_spec in ipairs(plugin_specs) do
+packer.use_with_context = function(ctx, ...)
+  for _, plugin_spec in ipairs { ... } do
+    if type(plugin_spec) == 'string' then
+      plugin_spec = { plugin_spec }
+    end
+
     packer.use(vim.tbl_deep_extend('keep', plugin_spec, ctx))
   end
 end


### PR DESCRIPTION
This PR adds a minor feature, the function `packer.use_with_context(ctx, ...)`. This is a convenience function intended to make it easier to specify a group of plugins which share some configuration keys.

Basic usage is:
```lua
use_with_context(
  {after = 'some-plugin', requires = 'some-common-library'}, 
  'my-plugin-1', 
  {'my-plugin-2', cmd = 'SomeCmd'}
)
```

This PR still needs to add documentation, and has not been thoroughly tested.
