### PR TITLE
Fix #659: Allow space-separated strings of plugin names in packer.loader

### DIFF
--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -765,8 +765,6 @@ packer.loader = function(...)
     )
   end
 
-  print(vim.inspect(plugin_list))
-
   require 'packer.load'(plugin_list, {}, _G.packer_plugins, force)
 end
 


### PR DESCRIPTION
This fixes a regression introduced in 755f7c4a1 by once again allowing packer.loader to accept lists of plugin names given as a single space-separated string/by including space-separated strings in the varargs given to packer.loader.

@ray-x: Can you please confirm that this closes #659 for you?