### PR TITLE
feat: add sync_then to accept a callback when sync is complete

### DIFF
--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -566,7 +566,7 @@ end
 --  - Clean stale plugins
 --  - Install missing plugins and update installed plugins
 --  - Update helptags and rplugins
-packer.sync = function(...)
+local function sync_then(callback, ...)
   local log = require_and_configure 'log'
   log.debug 'packer.sync: requiring modules'
   local plugin_utils = require_and_configure 'plugin_utils'
@@ -648,8 +648,12 @@ packer.sync = function(...)
     local delta = string.gsub(vim.fn.reltimestr(vim.fn.reltime(start_time)), ' ', '')
     display_win:final_results(results, delta, opts)
     packer.on_complete()
+    callback()
   end)()
 end
+
+packer.sync = function(...) return sync_then(function() end, ...) end
+packer.sync_then = sync_then
 
 packer.status = function()
   local async = require('packer.async').sync


### PR DESCRIPTION
With this function, we can solve https://github.com/wbthomason/packer.nvim/issues/198 a little nicer:

plugins.lua
```
return function(continue)
	local install_path = vim.fn.stdpath("data") .. "/site/pack/packer/start/packer.nvim"
	local packer_bootstrap

	if vim.fn.empty(vim.fn.glob(install_path)) > 0 then
		packer_bootstrap = vim.fn.system({
			"git",
			"clone",
			"--depth",
			"1",
			"https://github.com/wbthomason/packer.nvim",
			install_path,
		})
		vim.cmd("packadd packer.nvim")
	end

	return require("packer").startup(function(use)
		-- plugins here
                -- this could also be abstracted out
		if packer_bootstrap then
			require("packer").sync_then(continue)
		else
			continue()
		end
	end)
end
```
init.lua
```
local init = function()
	-- setup everything else
end

require("plugins")(init)
```

Might make sense to add a callback to every async function on the `packer` module.
What do people think?
