### PR TITLE
Fix: Don't duplicate URL in plugin info display on toggle

### DIFF
--- a/lua/packer/display.lua
+++ b/lua/packer/display.lua
@@ -606,6 +606,7 @@ local display_mt = {
       return
     end
 
+    local current_cursor_pos = api.nvim_win_get_cursor(0)
     local plugin_name, cursor_pos = self:find_nearest_plugin()
     if plugin_name == nil then
       log.warn 'No plugin selected!'
@@ -622,6 +623,8 @@ local display_mt = {
     else
       log.info('No further information for ' .. plugin_name)
     end
+
+    api.nvim_win_set_cursor(0, current_cursor_pos)
   end,
 
   diff = function(self)

--- a/lua/packer/display.lua
+++ b/lua/packer/display.lua
@@ -708,12 +708,17 @@ local display_mt = {
     if not self:valid_display() then
       return
     end
+
     local cursor_pos = api.nvim_win_get_cursor(0)
     -- TODO: this is a dumb hack
     for i = cursor_pos[1], 1, -1 do
       local curr_line = api.nvim_buf_get_lines(0, i - 1, i, true)[1]
       for name, _ in pairs(self.items) do
         if string.find(curr_line, name, 1, true) then
+          if string.find(curr_line, '  URL:', 1, true) then
+            i = i - 1
+          end
+
           return name, { i, 0 }
         end
       end


### PR DESCRIPTION
After #658, we display plugin URLs in the status window after an update. Unfortunately, this broke the simple heuristic used for finding the nearest plugin name to determine which set of info to toggle, because plugin names now appear in two places. This PR fixes that bug by checking for the ' URL:' prefix to a line, and additionally fixes a minor bug wherein we were not restoring cursor position after toggling.

@n3wborn: Can you please confirm that this closes #681 for you?
