### PR TITLE
Feature: Add option to specify use_rocks-style Luarocks in the table form of startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,8 +271,8 @@ The following is a more in-depth explanation of `packer`'s features and use.
 - `spec` can be a function: `packer.startup(function() use 'tjdevries/colorbuddy.vim' end)`
 - `spec` can be a table with a function as its first element and config overrides as another element:
   `packer.startup({function() use 'tjdevries/colorbuddy.vim' end, config = { ... }})`
-- `spec` can be a table with a table of plugin specifications as its first element and config overrides as another element:
- `packer.startup({{'tjdevries/colorbuddy.vim'}, config = { ... }})`
+- `spec` can be a table with a table of plugin specifications as its first element, config overrides as another element, and optional rock specifications as another element:
+ `packer.startup({{'tjdevries/colorbuddy.vim'}, config = { ... }, rocks = { ... }})`
 
 ### Custom Initialization
 You are not required to use `packer.startup` if you prefer a more manual setup with finer control

--- a/doc/packer.txt
+++ b/doc/packer.txt
@@ -147,8 +147,9 @@ short, `startup` is a convenience function for simple setup, and is invoked as
     function() use 'tjdevries/colorbuddy.vim' end, config = { ... }
     })
 - `spec` can be a table with a table of plugin specifications as its first
-  element and config overrides as another element: >
-  packer.startup({{'tjdevries/colorbuddy.vim'}, config = { ... }})
+  element, config overrides as another element, and optional rock
+  specifications as another element: >
+  packer.startup({{'tjdevries/colorbuddy.vim'}, config = { ... }, rocks = { ... }})
 
 See |packer-configuration| for the allowed configuration keys.
 

--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -805,14 +805,15 @@ packer.config = config
 --  element:
 --  packer.startup({function() use 'tjdevries/colorbuddy.vim' end, config = { ... }})
 --
---  spec can be a table with a table of plugin specifications as its first element and config
---  overrides as another element:
---  packer.startup({{'tjdevries/colorbuddy.vim'}, config = { ... }})
+--  spec can be a table with a table of plugin specifications as its first element, config overrides
+--  as another element, and an optional table of Luarocks rock specifications as another element:
+--  packer.startup({{'tjdevries/colorbuddy.vim'}, config = { ... }, rocks = { ... }})
 packer.startup = function(spec)
   local log = require_and_configure 'log'
   local user_func = nil
   local user_config = nil
   local user_plugins = nil
+  local user_rocks = nil
   if type(spec) == 'function' then
     user_func = spec
   elseif type(spec) == 'table' then
@@ -820,6 +821,7 @@ packer.startup = function(spec)
       user_func = spec[1]
     elseif type(spec[1]) == 'table' then
       user_plugins = spec[1]
+      user_rocks = spec.rocks
     else
       log.error 'You must provide a function or table of specifications as the first element of the argument to startup!'
       return
@@ -843,6 +845,9 @@ packer.startup = function(spec)
     end
   else
     packer.use(user_plugins)
+    if user_rocks then
+      packer.use_rocks(user_rocks)
+    end
   end
 
   return packer


### PR DESCRIPTION
Fixes an oversight wherein there was no way to add rocks separate from a plugin (i.e. the `use_rocks` style) if you use the table-only form of `packer.startup`.
