### PR TITLE
Fix: packadd start and opt plugins on install

### DIFF
--- a/lua/packer/plugin_utils.lua
+++ b/lua/packer/plugin_utils.lua
@@ -183,30 +183,6 @@ end
 
 plugin_utils.load_plugin = function(plugin)
   vim.cmd('packadd ' .. plugin.short_name)
-  if not plugin.opt then
-    vim.o.runtimepath = vim.o.runtimepath .. ',' .. plugin.install_path
-    for _, pat in
-      ipairs {
-        table.concat({ 'plugin', '**/*.vim' }, util.get_separator()),
-        table.concat({ 'after', 'plugin', '**/*.vim' }, util.get_separator()),
-      }
-    do
-      local path = util.join_paths(plugin.install_path, pat)
-      local glob_ok, files = pcall(vim.fn.glob, path, false, true)
-      if not glob_ok then
-        if string.find(files, 'E77') then
-          vim.cmd('silent exe "source ' .. path .. '"')
-        else
-          error(files)
-        end
-      elseif #files > 0 then
-        for _, file in ipairs(files) do
-          file = file:gsub('\\', '/')
-          vim.cmd('silent exe "source ' .. file .. '"')
-        end
-      end
-    end
-  end
 end
 
 plugin_utils.post_update_hook = function(plugin, disp)

--- a/lua/packer/plugin_utils.lua
+++ b/lua/packer/plugin_utils.lua
@@ -182,14 +182,15 @@ plugin_utils.get_fs_state = function(plugins)
 end
 
 plugin_utils.load_plugin = function(plugin)
-  if plugin.opt then
-    vim.cmd('packadd ' .. plugin.short_name)
-  else
+  vim.cmd('packadd ' .. plugin.short_name)
+  if not plugin.opt then
     vim.o.runtimepath = vim.o.runtimepath .. ',' .. plugin.install_path
-    for _, pat in ipairs {
-      table.concat({ 'plugin', '**/*.vim' }, util.get_separator()),
-      table.concat({ 'after', 'plugin', '**/*.vim' }, util.get_separator()),
-    } do
+    for _, pat in
+      ipairs {
+        table.concat({ 'plugin', '**/*.vim' }, util.get_separator()),
+        table.concat({ 'after', 'plugin', '**/*.vim' }, util.get_separator()),
+      }
+    do
       local path = util.join_paths(plugin.install_path, pat)
       local glob_ok, files = pcall(vim.fn.glob, path, false, true)
       if not glob_ok then


### PR DESCRIPTION
This PR fixes initial plugin loading after installation. We need to `packadd` both `opt` and `start` plugins in order for `require`, etc. to work.
I'm also trying out removing the manual sourcing we'd included originally---I'm not sure when `packadd` behavior changed, but it's possible that this is now redundant. We'll need to test on a non-`HEAD` Neovim version to be sure.
