### PR TITLE
Handle unreachable git repos without nil exception

### DIFF
--- a/lua/packer/plugin_types/git.lua
+++ b/lua/packer/plugin_types/git.lua
@@ -329,7 +329,11 @@ git.setup = function(plugin)
         r:map_err(function(err)
           merge_output(err)
           plugin.output = { err = vim.list_extend(update_info.err, update_info.output), data = {} }
-          return { msg = err.msg .. ' ' .. table.concat(update_info.output, '\n'), data = err.data }
+          local errmsg = '<unknown error>'
+          if err ~= nil and err.msg ~= nil then
+            errmsg = err.msg
+          end
+          return { msg = errmsg .. ' ' .. table.concat(update_info.output, '\n'), data = err.data }
         end)
       end
 

--- a/lua/packer/update.lua
+++ b/lua/packer/update.lua
@@ -94,7 +94,11 @@ local function update_plugin(plugin, display_win, results)
       end
     else
       display_win:task_failed(plugin_name, 'failed to update')
-      log.debug(fmt('Failed to update %s: %s', plugin_name, vim.inspect(r.err)))
+      local errmsg = '<unknown error>'
+      if r ~= nil and r.err ~= nil then
+        errmsg = r.err
+      end
+      log.debug(fmt('Failed to update %s: %s', plugin_name, vim.inspect(errmsg)))
     end
 
     results.updates[plugin_name] = r


### PR DESCRIPTION
If a git repo is not reachable a nil exception is thrown (neovim v7 nightly)

These small changes handle this scenario without crashing out.