### PR TITLE
Tag Wildcards support

### DIFF
--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -38,6 +38,7 @@ local config_defaults = {
       get_bodies = 'log --color=never --pretty=format:"===COMMIT_START===%h%n%s===BODY_START===%b" --no-show-signature HEAD@{1}...HEAD',
       submodules = 'submodule update --init --recursive --progress',
       revert = 'reset --hard HEAD@{1}',
+      tags_expand_fmt = 'tag -l %s --sort -version:refname',
     },
     depth = 1,
     clone_timeout = 60,

--- a/lua/packer/plugin_types/git.lua
+++ b/lua/packer/plugin_types/git.lua
@@ -87,6 +87,9 @@ local handle_checkouts = function(plugin, dest, disp)
       local data = output.data.stdout[1]
       if data then
         plugin.tag = vim.split(data, '\n')[1]
+      else
+        -- TODO: show warning
+        plugin.tag = nil -- Wildcard is not found, then we bypass the tag
       end
     end
 
@@ -215,17 +218,6 @@ git.setup = function(plugin)
               data = { err, output },
             }
           end)
-      elseif plugin.tag and has_wildcard() then
-        -- disp:task_update(plugin_name, fmt('getting tag %s...', plugin.tag))
-        -- local test = config.exec_cmd .. fmt(config.subcommands.tags_expand_fmt, plugin.tag)
-        -- r:and_then(await, jobs.run(test, installer_opts)):map_ok(function()
-        --   local data = output.data.stdout[1]
-        --   if data then
-        --     plugin.tag = vim.split(data, '\n')[1]
-        --     r:and_then(await, handle_checkouts(plugin, install_to, disp))
-        --   end
-        --   -- TODO: error
-        -- end)
       end
 
       r

--- a/lua/packer/plugin_types/git.lua
+++ b/lua/packer/plugin_types/git.lua
@@ -2,6 +2,7 @@ local util = require 'packer.util'
 local jobs = require 'packer.jobs'
 local a = require 'packer.async'
 local result = require 'packer.result'
+local log = require 'packer.log'
 local await = a.wait
 local async = a.sync
 local fmt = string.format
@@ -88,7 +89,9 @@ local handle_checkouts = function(plugin, dest, disp)
       if data then
         plugin.tag = vim.split(data, '\n')[1]
       else
-        -- TODO: show warning
+        log.warn(
+          fmt('Wildcard expansion did not found any tag for plugin %s: defaulting to latest commit...', plugin.name)
+        )
         plugin.tag = nil -- Wildcard is not found, then we bypass the tag
       end
     end


### PR DESCRIPTION
Hello, 

Providing support for wildcards, as discussed in #529, in the effort of providing plugin managers ways to follow plugin versioning.

For example, if the plugin has these tags:
```
1.0.0
0.1.0
0.0.11
0.0.10
```

And you add `tag = "0.0.*"`, it'll follow `0.0.11`. Doing `tag = "*"` will follow latest tag. 
If the wildcard expansion did not succeed, will default to latest commit with a warning log.

Some TODO:

- [x] Installing a plugin with wildcard tag
- [x] Updating a plugin with wildcard tag
- [x] Proper error handling if wildcard did not catch a tag
- [x] Verifying consistency for plugins without tags
- [x] Verifying consistency for plugins with tags but without wildcards
- [ ] Update help file + readme 