### PR TITLE
Add packer itself to bootstrapping in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ if fn.empty(fn.glob(install_path)) > 0 then
 end
 
 return require('packer').startup(function(use)
+  use 'wbthomason/packer.nvim'
   -- My plugins here
   -- use 'foo1/bar1.nvim'
   -- use 'foo2/bar2.nvim'


### PR DESCRIPTION
When you copy/paste the bootstrapping code from the README packer will install but try to remove itself again right away. No matter if you answer yes or no to the question you get a 'display_win' error.