### PR TITLE
Escape doublequotes to prevent cryptic errors while trying to report …

### DIFF
--- a/lua/packer/compile.lua
+++ b/lua/packer/compile.lua
@@ -46,6 +46,7 @@ local catch_errors_lua = [[
 end)
 
 if not no_errors then
+  error_msg = error_msg:gsub('"', '\\"')
   vim.api.nvim_command('echohl ErrorMsg | echom "Error in packer_compiled: '..error_msg..'" | echom "Please check your config for correctness" | echohl None')
 end
 ]]


### PR DESCRIPTION
This tiny fix prevent situation where the `error_msg` variable contains `"`.
When it does. the vimscript command `echom` will fail because part of the original `error_msg` will be outside of the quotes.

For example, if a plugin is configured like this:
```lua
{"author/reponame", event = "NoSuchEvent"},
```
The error message in `error_msg` will be something like:
```
Vim(autocmd):E216: No such group or event: NoSuchEvent * ++once lua require("packer.load")({'reponame'}, { event = "NoSuchEvent *" }, _G.packer_plugins)
```

The doublequotes in the `require` will make the `echom` command to fail.