### PR TITLE
feat: add option for quiet compilation

### DIFF
--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -333,8 +333,10 @@ end)
 
 --- Hook to fire events after packer compilation
 packer.on_compile_done = function()
+  local log = require_and_configure 'log'
+
   vim.cmd [[doautocmd User PackerCompileDone]]
-  vim.notify('packer.compile: Complete', vim.log.levels.INFO, { title = 'packer.nvim' })
+  log.debug 'packer.compile: Complete'
 end
 
 --- Clean operation:


### PR DESCRIPTION
Somewhat trivial case, but I run `packer.compile` at startup and wish I could turn off the notification. Thanks for all your hard work!