### PR TITLE
Load and use snapshots as part of init for installation without 'startup'

### DIFF
--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -10,6 +10,7 @@ local packer = {}
 local config_defaults = {
   ensure_dependencies = true,
   snapshot = nil,
+  snapshot_commits = {},
   snapshot_path = join_paths(stdpath 'cache', 'packer.nvim'),
   package_root = join_paths(stdpath 'data', 'site', 'pack'),
   compile_path = join_paths(stdpath 'config', 'plugin', 'packer_compiled.lua'),
@@ -130,6 +131,12 @@ packer.init = function(user_config)
   if vim.fn.mkdir(config.snapshot_path, 'p') ~= 1 then
     vim.notify("Couldn't create " .. config.snapshot_path, vim.log.levels.WARN)
   end
+
+  if config.snapshot then
+    local content = vim.fn.readfile(config.snapshot)
+    config.snapshot_commits = vim.fn.json_decode(content)
+  end
+
 end
 
 packer.make_commands = function()
@@ -228,6 +235,10 @@ manage = function(plugin_data)
   plugin_spec.short_name = name
   plugin_spec.name = path
   plugin_spec.path = path
+
+  if (config.snapshot_commits[plugin_spec.short_name] ~= nil) then
+    plugin_spec = vim.tbl_extend('keep', plugin_spec, config.snapshot_commits[plugin_spec.short_name])
+  end
 
   -- Some config keys modify a plugin type
   if plugin_spec.opt then


### PR DESCRIPTION
Not a complete fix but it attempts to better describe the problem of needing to use a snapshot at install/sync time for configurations that are not calling 'packer.startup'. (e.g config similar to https://github.com/wbthomason/dotfiles/blob/linux/neovim/.config/nvim/lua/plugins.lua  and https://github.com/wbthomason/dotfiles/blob/linux/neovim/.config/nvim/init.lua#L100 )