### PR TITLE
fix(luarocks): use lower string as package name

### DIFF
--- a/lua/packer/luarocks.lua
+++ b/lua/packer/luarocks.lua
@@ -486,10 +486,9 @@ local function ensure_rocks(rocks, results, disp)
     local to_install = {}
     for _, rock in pairs(rocks) do
       if type(rock) == 'table' then
-        to_install[rock[1]] = rock
-      else
-        to_install[rock] = true
+        rock = rock[1]
       end
+      to_install[string.lower(rock)] = true
     end
 
     local r = result.ok()


### PR DESCRIPTION
If package name contains any uppercase chars, PackerUpdate action always displays `✓ Installed packerName`.

reference:
- https://github.com/luarocks/luarocks/blob/8f3ce333e7a1abfc6bf0488817d9eff4a2fd443f/src/luarocks/rockspecs.lua#L121