### PR TITLE
Expose functionality to get a plugin's short name

### DIFF
--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -193,14 +193,7 @@ manage = function(plugin_data)
     return
   end
 
-  local path = vim.fn.expand(plugin_spec[1])
-  local name_segments = vim.split(path, util.get_separator())
-  local segment_idx = #name_segments
-  local name = plugin_spec.as or name_segments[segment_idx]
-  while name == '' and segment_idx > 0 do
-    name = name_segments[segment_idx]
-    segment_idx = segment_idx - 1
-  end
+  local name, path = util.get_plugin_short_name(plugin_spec)
 
   if name == '' then
     log.warn('"' .. plugin_spec[1] .. '" is an invalid plugin name!')

--- a/lua/packer/util.lua
+++ b/lua/packer/util.lua
@@ -53,6 +53,18 @@ util.join_paths = function(...)
   return table.concat({ ... }, separator)
 end
 
+util.get_plugin_short_name = function(plugin)
+  local path = vim.fn.expand(plugin[1])
+  local name_segments = vim.split(path, util.get_separator())
+  local segment_idx = #name_segments
+  local name = plugin.as or name_segments[segment_idx]
+  while name == '' and segment_idx > 0 do
+    name = name_segments[segment_idx]
+    segment_idx = segment_idx - 1
+  end
+  return name, path
+end
+
 util.get_plugin_full_name = function(plugin)
   local plugin_name = plugin.name
   if plugin.branch and plugin.branch ~= 'master' then


### PR DESCRIPTION
I'm preprocessing plugin specs at the moment (until the config merging PR lands) and, in that context, it's sometimes useful to refer to a plugin's canonical short name outside of packer. I figured why not expose the functionality in general?

If you think this isn't necessary, feel free to close this, of course. :)