### PR TITLE
patch: Use Lua autocmd API

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,23 +201,15 @@ You can configure Neovim to automatically run `:PackerCompile` whenever `plugins
 [an autocommand](https://neovim.io/doc/user/autocmd.html#:autocmd):
 
 ```
-augroup packer_user_config
-  autocmd!
-  autocmd BufWritePost plugins.lua source <afile> | PackerCompile
-augroup end
+local group = vim.api.nvim_create_augroup("packer_user_config", { clear = true })
+vim.api.nvim_create_autocmd("BufWritePost", {
+  command = "PackerCompile",
+  pattern = "plugins.lua",
+  group = group,
+})
 ```
 
-This autocommand can be placed in your `init.vim`, or any other startup file as per your setup.
-Placing this in `plugins.lua` could look like this:
-
-```lua
-vim.cmd([[
-  augroup packer_user_config
-    autocmd!
-    autocmd BufWritePost plugins.lua source <afile> | PackerCompile
-  augroup end
-]])
-```
+This autocommand can be placed in your `init.vim`, in `plugins.lua`, or any other startup file as per your setup.
 
 ## Bootstrapping
 


### PR DESCRIPTION
Make use of the new API implemented in
https://github.com/neovim/neovim/pull/14661.

This API is not yet released, but will probably be released with Neovim
0.7 (see https://github.com/neovim/neovim/milestone/29). So I guess you
can merge my PR when Neovim 0.7 is released?

I tried out this diff on the Git master of Neovim.