### PR TITLE
Add `nosuf = true` param to `vim.fn.expand()` call

### DIFF
--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -704,7 +704,7 @@ packer.compile = function(raw_args, move_plugins)
     refresh_configs(plugins)
     -- NOTE: we copy the plugins table so the in memory value is not mutated during compilation
     local compiled_loader = compile(vim.deepcopy(plugins), output_lua, should_profile)
-    output_path = vim.fn.expand(output_path)
+    output_path = vim.fn.expand(output_path, true)
     vim.fn.mkdir(vim.fn.fnamemodify(output_path, ':h'), 'p')
     local output_file = io.open(output_path, 'w')
     output_file:write(compiled_loader)


### PR DESCRIPTION
This change ensures that `output_path` doesn't get transformed into "" if `packer_compiled.lua` is in `&wildignore`.