### PR TITLE
Added note about nvim 0.7.0 lua autocmds

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,8 +222,10 @@ vim.cmd([[
 Since neovim 0.7.0 you can do this in lua too
 
 ```lua
+vim.api.nvim_create_augroup('packer_user_config', { clear = true })
 vim.api.nvim_create_autocmd('BufWritePost', {
-    pattern = 'plugins.lua'
+    group = 'packer_user_config',
+    pattern = 'plugins.lua',
     command = 'source <afile> | PackerCompile'
 })
 ```


### PR DESCRIPTION
neovim introduced native lua autocmds, so I though they'd be worth a mention.

I was considering adding an example with the `callback` field instead of `command` but couldn't find a lua variant of source, and doing it with `vim.cmd` would yield the same result as using command