### PR TITLE
Feat: add PackerSnapshotDone autocmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -562,6 +562,7 @@ require knowing when the operations are complete, you can use the following `Use
 
 - `PackerComplete`: Fires after install, update, clean, and sync asynchronous operations finish.
 - `PackerCompileDone`: Fires after compiling (see [the section on compilation](#compiling-lazy-loaders))
+- `PackerSnapshotDone`: Fires after snapshot done
 
 ### Using a floating window
 You can configure Packer to use a floating window for command outputs by passing a utility

--- a/doc/packer.txt
+++ b/doc/packer.txt
@@ -490,6 +490,7 @@ use):
 `PackerComplete`       Fires after install, update, clean, and sync
                      asynchronous operations finish.
 `PackerCompileDone`    Fires after compiling (see |packer-lazy-load|)
+`PackerSnapshotDone`   Fires after snapshot
 
 ==============================================================================
 API                                            *packer-api*

--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -344,6 +344,14 @@ packer.on_compile_done = function()
   log.debug 'packer.compile: Complete'
 end
 
+--- Hook to fire events after packer snapshot
+packer.on_snapshot_done = vim.schedule_wrap(function()
+  local log = require_and_configure 'log'
+
+  vim.cmd [[doautocmd User PackerSnapshotDone]]
+  log.debug 'packer.snapshot: Complete'
+end)
+
 --- Clean operation:
 -- Finds plugins present in the `packer` package but not in the managed set
 packer.clean = function(results)
@@ -869,6 +877,8 @@ packer.snapshot = function(snapshot_name, ...)
           vim.notify(err.message, vim.log.levels.WARN, { title = 'packer.nvim' })
         end)
     end
+
+    packer.on_snapshot_done()
   end)()
 end
 


### PR DESCRIPTION
### Description

Add a new `PackerSnapshotDone` autocmd which will be fired after `PackerSnapshot`  command.
Why? As https://github.com/wbthomason/packer.nvim/pull/370#issuecomment-1051643004 said, the snapshot file generated is not ordered or stable and is not ideal for checking into source control and easily seeing what changed. Before `packer` could expand and sort the generated  snapshot file, this is needed for more smooth experience of packer's snapshoot feature.

usage example:

```vim
autocmd User PackerSnapshotDone lua require('utils').sort_snapshot_file()
```

### Test

I have test the commits of the pull request in Archlinux-WSL and Windows 10 and in both environments the autocmd works well.

see usecase here <https://github.com/younger-1/nvim/blob/d0ce631b41644e841a25bc7eac0b053a288ce0fe/lua/young/plugin-loader.lua#L131-L132>
