### PR TITLE
Readme: fix code syntax in src block

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,7 +398,7 @@ use {
   module = string or list      -- Specifies Lua module names for require. When requiring a string which starts
                                -- with one of these module names, the plugin will be loaded.
   module_pattern = string/list -- Specifies Lua pattern of Lua module names for require. When
-  requiring a string which matches one of these patterns, the plugin will be loaded.
+                               -- requiring a string which matches one of these patterns, the plugin will be loaded.
 }
 ```
 


### PR DESCRIPTION
Added a missing `--` before a comment. This has been annoying me for a long time.

(The `string/list` in line 400 should probably also be turned into a `string or list`, but that would break the indent of the comment cascade..)