### PR TITLE
fix(compile): avoid overriding fields of plugins specified in 'after' key

### DIFF
--- a/lua/packer/compile.lua
+++ b/lua/packer/compile.lua
@@ -595,7 +595,9 @@ local function make_loaders(_, plugins, output_lua, should_profile)
     if plugins[pre].opt then
       loaders[pre].after = posts
     elseif plugins[pre].only_config then
-      loaders[pre] = { after = posts, only_sequence = true, only_config = true }
+      loaders[pre].after = posts
+      loaders[pre].only_sequence = true
+      loaders[pre].only_config = true
     end
 
     if plugins[pre].simple_load or plugins[pre].opt or plugins[pre].only_config then


### PR DESCRIPTION
After running `PackerCompile`, plugins specified in `after` key would miss some fields in the generated `packer_compiled.lua` file, for example, let `nvim-notify` be loaded after `telescope.nvim`:

```lua
...
use {
  'nvim-telescope/telescope.nvim',
  config = function()
    require('young.mod.telescope').done()
  end,
}
use {
  'rcarriga/nvim-notify',
  after = 'telescope.nvim',
}
...
```

and in the generated `packer_compiled.lua` file, loader for `telescope.nvim` would missing fields like `config`, `url` and `path` :

```lua
_G.packer_plugins = {
  ["telescope.nvim"] = {
    after = { "nvim-notify" },
    loaded = true,
    only_config = true
  },
}
```

After this fix, it would be normal:

```lua
_G.packer_plugins = {
  ["telescope.nvim"] = {
    after = { "nvim-notify" },
    config = { "\27LJ\2\n@\0\0\3\0\3\0\0066\0\0\0'\2\1\0B\0\2\0029\0\2\0B\0\1\1K\0\1\0\tdone\24young.mod.telescope\frequire\0" },
    loaded = true,
    only_config = true,
    path = "/home/xavier/.local/share/nvim/site/pack/packer/start/telescope.nvim",
    url = "https://github.com/nvim-telescope/telescope.nvim"
  },
}
```
