### PR TITLE
Fixed shallslash issue on Windows

### DIFF
--- a/lua/packer/util.lua
+++ b/lua/packer/util.lua
@@ -41,8 +41,15 @@ else
   util.is_windows = package.config:sub(1, 1) == '\\'
 end
 
+if vim.o.shellslash then
+  util.use_shellslash = true
+else
+  util.use_shallslash = false
+end
+
+
 util.get_separator = function()
-  if util.is_windows and not vim.o.shellslash then
+  if util.is_windows and not util.use_shellslash then
     return '\\'
   end
   return '/'

--- a/lua/packer/util.lua
+++ b/lua/packer/util.lua
@@ -42,7 +42,7 @@ else
 end
 
 util.get_separator = function()
-  if util.is_windows then
+  if util.is_windows and not vim.o.shellslash then
     return '\\'
   end
   return '/'


### PR DESCRIPTION
In some cases, there could be the need to activate the "shellslash" option on windows. In the current version of packer.nvim, this would create problems when installing new modules or doing a sync of the installed ones. It would not load any module after doing a sync. This is related to #911

I've added a check so that packer.nvim is able to handle the shellslash option. Tested locally by doing the "install" steps in the readme, and it worked flawlessly, I hope it could be of some help to others too.

Let me know what you think 🙂