### PR TITLE
Add packadd command to bootstrapping example

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ local fn = vim.fn
 local install_path = fn.stdpath('data')..'/site/pack/packer/start/packer.nvim'
 if fn.empty(fn.glob(install_path)) > 0 then
   packer_bootstrap = fn.system({'git', 'clone', '--depth', '1', 'https://github.com/wbthomason/packer.nvim', install_path})
+  vim.cmd('packadd packer.nvim')
 end
 
 return require('packer').startup(function(use)


### PR DESCRIPTION
Without the `packadd`, on first download packer won't be sourced, throwing a bunch of errors when trying to use the packer commands.