### PR TITLE
"Escape" [[ when compiler creates keybidings

### DIFF
--- a/lua/packer/compile.lua
+++ b/lua/packer/compile.lua
@@ -574,13 +574,19 @@ local function make_loaders(_, plugins, output_lua, should_profile)
     end
     local escaped_map_lt = string.gsub(keymap[2], '<', '<lt>')
     local escaped_map = string.gsub(escaped_map_lt, '([\\"])', '\\%1')
+    local nested = ''
+    while string.find(keymap[2], '[' .. nested .. ']') do
+      nested = ''
+    end
     local keymap_line = fmt(
-      'vim.cmd [[%snoremap <silent> %s <cmd>lua require("packer.load")({%s}, { keys = "%s"%s }, _G.packer_plugins)<cr>]]',
+      'vim.cmd [%s[%snoremap <silent> %s <cmd>lua require("packer.load")({%s}, { keys = "%s"%s }, _G.packer_plugins)<cr>]%s]',
+      nested,
       keymap[1],
       keymap[2],
       table.concat(names, ', '),
       escaped_map,
-      prefix == nil and '' or (', prefix = "' .. prefix .. '"')
+      prefix == nil and '' or (', prefix = "' .. prefix .. '"'),
+      nested
     )
 
     table.insert(keymap_defs, keymap_line)

--- a/lua/packer/compile.lua
+++ b/lua/packer/compile.lua
@@ -575,8 +575,8 @@ local function make_loaders(_, plugins, output_lua, should_profile)
     local escaped_map_lt = string.gsub(keymap[2], '<', '<lt>')
     local escaped_map = string.gsub(escaped_map_lt, '([\\"])', '\\%1')
     local nested = ''
-    while string.find(keymap[2], '[' .. nested .. ']') do
-      nested = ''
+    while string.find(keymap[2], ']' .. nested .. ']') do
+      nested = nested .. '='
     end
     local keymap_line = fmt(
       'vim.cmd [%s[%snoremap <silent> %s <cmd>lua require("packer.load")({%s}, { keys = "%s"%s }, _G.packer_plugins)<cr>]%s]',


### PR DESCRIPTION
Related isue: #485 
There is no way to escape [[ in multiline strings.
But it is posible to change the end of a multiline string by adding = betwene the [
This code makes that happen automatecly if any ]] is detected.
It also detects ]=], ]==] and so on.