### PR TITLE
Add packadd command to load packer when bootstrapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ local fn = vim.fn
 local install_path = fn.stdpath('data')..'/site/pack/packer/start/packer.nvim'
 if fn.empty(fn.glob(install_path)) > 0 then
   packer_bootstrap = fn.system({'git', 'clone', '--depth', '1', 'https://github.com/wbthomason/packer.nvim', install_path})
+  vim.api.nvim_command('packadd packer.nvim')
 end
 
 return require('packer').startup(function(use)


### PR DESCRIPTION
Opening Neovim for the first time trying to bootstrap packer would fail because packer wouldn't be loaded until the second time Neovim was opened.

Added the `packadd` command to correct this issue.