### PR TITLE
Rename variable on bootstraping script

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,10 +225,12 @@ If you want to automatically install and set up `packer.nvim` on any machine you
 add the following snippet (which is due to @Iron-E and @khuedoan) somewhere in your config **before** your first usage of `packer`:
 
 ```lua
+-- Automatically install packer if not found on disk then set a local variable to show it's just installed
 local fn = vim.fn
 local install_path = fn.stdpath('data')..'/site/pack/packer/start/packer.nvim'
+local packer_just_installed = nil
 if fn.empty(fn.glob(install_path)) > 0 then
-  packer_bootstrap = fn.system({'git', 'clone', '--depth', '1', 'https://github.com/wbthomason/packer.nvim', install_path})
+  packer_just_installed = fn.system({'git', 'clone', '--depth', '1', 'https://github.com/wbthomason/packer.nvim', install_path})
 end
 
 return require('packer').startup(function(use)
@@ -238,7 +240,7 @@ return require('packer').startup(function(use)
 
   -- Automatically set up your configuration after cloning packer.nvim
   -- Put this at the end after all plugins
-  if packer_bootstrap then
+  if packer_just_installed then
     require('packer').sync()
   end
 end)


### PR DESCRIPTION
`packer_bootstrap` sounds very "oficial", at first I thought it had special properties.

- renamed to `packer_just_installed`
- made it local (lsp complains that global vars should be uppercase)
- added a comment, so future me don't hate me