### PR TITLE
fix(luarocks): rock metadata not passed in install

### DIFF
--- a/lua/packer/luarocks.lua
+++ b/lua/packer/luarocks.lua
@@ -486,9 +486,10 @@ local function ensure_rocks(rocks, results, disp)
     local to_install = {}
     for _, rock in pairs(rocks) do
       if type(rock) == 'table' then
-        rock = rock[1]
+        to_install[rock[1]:lower()] = rock
+      else
+        to_install[rock:lower()] = true
       end
-      to_install[string.lower(rock)] = true
     end
 
     local r = result.ok()

--- a/tests/helpers.lua
+++ b/tests/helpers.lua
@@ -1,6 +1,6 @@
-local util = require("packer.util")
+local util = require 'packer.util'
 
-local M = {base_dir = "/tmp/__packer_tests__"}
+local M = { base_dir = '/tmp/__packer_tests__' }
 
 ---Create a fake git repository
 ---@param name string
@@ -8,13 +8,20 @@ local M = {base_dir = "/tmp/__packer_tests__"}
 function M.create_git_dir(name, base)
   base = base or M.base_dir
   local repo_path = util.join_paths(base, name)
-  local path = util.join_paths(repo_path, ".git")
-  vim.fn.mkdir(path, "p")
+  local path = util.join_paths(repo_path, '.git')
+  if vim.fn.isdirectory(path) > 0 then
+    M.cleanup_dirs(path)
+  end
+  vim.fn.mkdir(path, 'p')
   return repo_path
 end
 
 ---Remove directories created for test purposes
 ---@vararg string
-function M.cleanup_dirs(...) for _, dir in ipairs({...}) do vim.fn.delete(dir, "rf") end end
+function M.cleanup_dirs(...)
+  for _, dir in ipairs { ... } do
+    vim.fn.delete(dir, 'rf')
+  end
+end
 
 return M


### PR DESCRIPTION
PR #857 introduced a change which prevents the full data from a rock
from being used in its installation, e.g.

```lua
{
  "lyaml", server = "http://server", env = {YAML_DIR = "/usr/local"}
}
-- Is changed to
{"lyaml"}
```

Was no longer being passed as each rock was being transformed to just
it's name with not metadata passed on during the case change

@kevinhwang91 can you please check if your usecase is still satisfied with the change in case of the rocks. If so I'll merge this unless @wbthomason steps in