### PR TITLE
Fixed problem with previous PR on the shellslash option

### DIFF
--- a/lua/packer/util.lua
+++ b/lua/packer/util.lua
@@ -42,7 +42,7 @@ else
 end
 
 local shellslash_exists, _ = pcall(function() local _ = vim.o.shellslash end)
-local use_shellslash = false
+util.use_shellslash = false
 
 if shellslash_exists then
   util.use_shellslash = vim.o.shellslash

--- a/lua/packer/util.lua
+++ b/lua/packer/util.lua
@@ -41,10 +41,11 @@ else
   util.is_windows = package.config:sub(1, 1) == '\\'
 end
 
-if vim.o.shellslash then
-  util.use_shellslash = true
-else
-  util.use_shallslash = false
+local shellslash_exists, _ = pcall(function() local _ = vim.o.shellslash end)
+local use_shellslash = false
+
+if shellslash_exists then
+  util.use_shellslash = vim.o.shellslash
 end
 
 

--- a/lua/packer/util.lua
+++ b/lua/packer/util.lua
@@ -41,8 +41,15 @@ else
   util.is_windows = package.config:sub(1, 1) == '\\'
 end
 
+if vim.o.shellslash then
+  util.use_shellslash = true
+else
+  util.use_shallslash = false
+end
+
+
 util.get_separator = function()
-  if util.is_windows and not vim.o.shellslash then
+  if util.is_windows and not util.use_shellslash then
     return '\\'
   end
   return '/'

--- a/lua/packer/util.lua
+++ b/lua/packer/util.lua
@@ -42,7 +42,7 @@ else
 end
 
 util.get_separator = function()
-  if util.is_windows then
+  if util.is_windows and not vim.o.shellslash then
     return '\\'
   end
   return '/'


### PR DESCRIPTION
There was an issue with my previous PR if you were on Linux and the shellslash option was not available. Now this has been fixed (tested on linux and windows with and without the shellslash option).