### PR TITLE
feat: treat "type!:" pattern as a breaking change

### DIFF
--- a/lua/packer/plugin_types/git.lua
+++ b/lua/packer/plugin_types/git.lua
@@ -41,8 +41,10 @@ local function has_wildcard(tag)
   return string.match(tag, '*') ~= nil
 end
 
-local break_tag_pattern = [=[[bB][rR][eE][aA][kK]!?:]=]
+local break_tag_pattern = [=[[bB][rR][eE][aA][kK]:]=]
 local breaking_change_pattern = [=[[bB][rR][eE][aA][kK][iI][nN][gG][ _][cC][hH][aA][nN][gG][eE]]=]
+local type_exclam_pattern = [=[[a-zA-Z]+!:]=]
+local type_scope_exclam_pattern = [=[[a-zA-Z]+%([^)]+%)!:]=]
 local function mark_breaking_commits(plugin, commit_bodies)
   local commits = vim.gsplit(table.concat(commit_bodies, '\n'), '===COMMIT_START===', true)
   for commit in commits do
@@ -50,13 +52,21 @@ local function mark_breaking_commits(plugin, commit_bodies)
     local body = commit_parts[2]
     local lines = vim.split(commit_parts[1], '\n')
     local is_breaking = (
-      body ~= nil
-      and ((string.match(body, breaking_change_pattern) ~= nil) or (string.match(body, break_tag_pattern) ~= nil))
-    )
+        body ~= nil
+        and (
+          (string.match(body, breaking_change_pattern) ~= nil)
+          or (string.match(body, break_tag_pattern) ~= nil)
+          or (string.match(body, type_exclam_pattern) ~= nil)
+          or (string.match(body, type_scope_exclam_pattern) ~= nil)
+        )
+      )
       or (
         lines[2] ~= nil
         and (
-          (string.match(lines[2], breaking_change_pattern) ~= nil) or (string.match(lines[2], break_tag_pattern) ~= nil)
+          (string.match(lines[2], breaking_change_pattern) ~= nil)
+          or (string.match(lines[2], break_tag_pattern) ~= nil)
+          or (string.match(lines[2], type_exclam_pattern) ~= nil)
+          or (string.match(lines[2], type_scope_exclam_pattern) ~= nil)
         )
       )
     if is_breaking then


### PR DESCRIPTION
This PR will add the ability to recognize these pretty common formats:

- `type!: body`
- `type(scope)!: body`

## Current behavior

![before](https://user-images.githubusercontent.com/72330683/184474342-79a9c2c8-d882-4cbc-ba08-5f516bcbd04b.png)

## This PR

![after](https://user-images.githubusercontent.com/72330683/184474352-85d8ef7b-2ff9-4aec-8954-0150cb90b855.png)
