### PR TITLE
fix(update): Validate local symlinks on update

### DIFF
--- a/lua/packer/plugin_types/local.lua
+++ b/lua/packer/plugin_types/local.lua
@@ -15,7 +15,7 @@ end
 -- Due to #679, we know that fs_symlink requires admin privileges on Windows. This is a workaround,
 -- as suggested by @nonsleepr.
 
-local symlink_fn unlink_fn
+local symlink_fn
 if util.is_windows then
   symlink_fn = function(path, new_path, flags, callback)
     flags = flags or {}

--- a/lua/packer/util.lua
+++ b/lua/packer/util.lua
@@ -54,6 +54,11 @@ util.get_separator = function()
   return '/'
 end
 
+util.strip_trailing_sep = function(path)
+  local res, _ = string.gsub(path, util.get_separator() .. '$', '', 1)
+  return res
+end
+
 util.join_paths = function(...)
   local separator = util.get_separator()
   return table.concat({ ... }, separator)


### PR DESCRIPTION
If a local plugin is installed and then the path is moved this was not
checked for in the local update function. This change checks if the
current dest link points to the desired src. If not then the link is
re-created.

Resolves: #944 