### PR TITLE
Remove redundant name check when registering a plugin

### DIFF
--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -208,19 +208,6 @@ manage = function(plugin_data)
     return
   end
 
-  if plugin_spec.as and plugins[plugin_spec.as] then
-    log.error(
-      'The alias '
-        .. plugin_spec.as
-        .. ', specified for '
-        .. path
-        .. ' at '
-        .. spec_line
-        .. ' is already used as another plugin name!'
-    )
-    return
-  end
-
   -- Handle aliases
   plugin_spec.short_name = name
   plugin_spec.name = path


### PR DESCRIPTION
`name` is equal to `plugin_spec.as` when the latter is set by `get_plugin_short_name()`. The conflict check against the alias is thus redundant.

Dropping this allows plugins to require aliased plugins, see #1017.