### PR TITLE
fix(git): remove `.git` from end url only

### DIFF
--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -264,7 +264,7 @@ manage = function(plugin_data)
   end
 
   -- Add the git URL for displaying in PackerStatus and PackerSync.
-  plugins[plugin_spec.short_name].url = plugin_spec.url:gsub('%.git', '')
+  plugins[plugin_spec.short_name].url = util.remove_ending_git_url(plugin_spec.url)
 
   if plugin_spec.requires and config.ensure_dependencies then
     if type(plugin_spec.requires) == 'string' then

--- a/lua/packer/util.lua
+++ b/lua/packer/util.lua
@@ -85,6 +85,10 @@ util.get_plugin_full_name = function(plugin)
   return plugin_name
 end
 
+util.remove_ending_git_url = function(url)
+  return url:find '%s.git$' and url:sub(1, -4) or url
+end
+
 util.deep_extend = function(policy, ...)
   local result = {}
   local function helper(policy, k, v1, v2)


### PR DESCRIPTION
Removes `.git` from url only if it ends with `.git`.

Resolves: #1022 