### PR TITLE
fix(git): correct `.git` pattern from end url

### DIFF
--- a/lua/packer/util.lua
+++ b/lua/packer/util.lua
@@ -86,7 +86,7 @@ util.get_plugin_full_name = function(plugin)
 end
 
 util.remove_ending_git_url = function(url)
-  return url:find '%s.git$' and url:sub(1, -4) or url
+  return url:find '%.git$' and url:sub(1, -4) or url
 end
 
 util.deep_extend = function(policy, ...)


### PR DESCRIPTION
Correct Lua pattern from #1023, resolves https://github.com/axieax/urlview.nvim/issues/32