### PR TITLE
fix(git): use vim.endswith to check git suffix

### DIFF
--- a/lua/packer/util.lua
+++ b/lua/packer/util.lua
@@ -86,7 +86,7 @@ util.get_plugin_full_name = function(plugin)
 end
 
 util.remove_ending_git_url = function(url)
-  return url:find '%.git$' and url:sub(1, -4) or url
+  return vim.endswith(url, '.git') and url:sub(1, -5) or url
 end
 
 util.deep_extend = function(policy, ...)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/62098008/185952553-d995a2fc-2d49-44a1-a6a8-193b3b43a116.png)

@akinsho apologies but it seems like there's still a dangling period character left behind from the previous commits. This should hopefully address it!