### PR TITLE
source lua files in `load_plugin`

### DIFF
--- a/lua/packer/plugin_utils.lua
+++ b/lua/packer/plugin_utils.lua
@@ -188,20 +188,23 @@ plugin_utils.load_plugin = function(plugin)
     vim.o.runtimepath = vim.o.runtimepath .. ',' .. plugin.install_path
     for _, pat in ipairs {
       table.concat({ 'plugin', '**/*.vim' }, util.get_separator()),
+      table.concat({ 'plugin', '**/*.lua' }, util.get_separator()),
       table.concat({ 'after', 'plugin', '**/*.vim' }, util.get_separator()),
+      table.concat({ 'after', 'plugin', '**/*.lua' }, util.get_separator()),
     } do
+      local cmd = vim.endswith(pat, 'lua') and 'luafile' or 'source'
       local path = util.join_paths(plugin.install_path, pat)
       local glob_ok, files = pcall(vim.fn.glob, path, false, true)
       if not glob_ok then
         if string.find(files, 'E77') then
-          vim.cmd('silent exe "source ' .. path .. '"')
+          vim.cmd('silent exe "' .. cmd .. ' ' .. path .. '"')
         else
           error(files)
         end
       elseif #files > 0 then
         for _, file in ipairs(files) do
           file = file:gsub('\\', '/')
-          vim.cmd('silent exe "source ' .. file .. '"')
+          vim.cmd('silent exe "' .. cmd .. ' ' .. file .. '"')
         end
       end
     end


### PR DESCRIPTION
(This is a recreation of https://github.com/wbthomason/packer.nvim/pull/1030, which I accidentally closed by force pushing)

When installing packer from a clean slate[1], and running `packer.sync()` with config containing
```lua
use({"nvim-treesitter/nvim-treesitter", run = ":TSUpdate" })
``` 
I'd see the following error in my `:messages` (similar to https://github.com/wbthomason/packer.nvim/issues/897#issuecomment-1114244296):
```
[packer.nvim] [ERROR 20:50:19] async.lua:20: Error in coroutine: ...ack/packer/start/packer.nvim/lua/packer/plugin_utils.lua:236: Vim:E492: Not an editor command: TSUpdate
```

I think this is because nvim-treesitter sets up the `:TSUpdate` command in [`plugin/nvim-treesitter.lua`](https://github.com/nvim-treesitter/nvim-treesitter/blob/fb4ad06a23caf49a9a6543fa59eb382a2e24280f/plugin/nvim-treesitter.lua#L9) and packer only sources `.vim` files when loading a plugin.

After making the change to also source `.lua` files, I no longer see the error message.

[1] `rm -rf ~/.local/share/nvim/site/pack/packer && rm ~/.config/nvim/plugin/packer_compiled.lua`