### PR TITLE
feat(git): support showing diff of range of commits

### DIFF
--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -34,8 +34,7 @@ local config_defaults = {
       current_branch = 'rev-parse --abbrev-ref HEAD',
       diff = 'log --color=never --pretty=format:FMT --no-show-signature HEAD@{1}...HEAD',
       diff_fmt = '%%h %%s (%%cr)',
-      -- TODO maybe --no-pager should be added for all commands?
-      git_diff_fmt = '--no-pager show --no-color --pretty=medium %s',
+      git_diff_fmt = 'show --no-color --pretty=medium %s',
       get_rev = 'rev-parse --short HEAD',
       get_header = 'log --color=never --pretty=format:FMT --no-show-signature HEAD -n 1',
       get_bodies = 'log --color=never --pretty=format:"===COMMIT_START===%h%n%s===BODY_START===%b" --no-show-signature HEAD@{1}...HEAD',

--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -34,7 +34,8 @@ local config_defaults = {
       current_branch = 'rev-parse --abbrev-ref HEAD',
       diff = 'log --color=never --pretty=format:FMT --no-show-signature HEAD@{1}...HEAD',
       diff_fmt = '%%h %%s (%%cr)',
-      git_diff_fmt = 'show --no-color --pretty=medium %s',
+      -- TODO maybe --no-pager should be added for all commands?
+      git_diff_fmt = '--no-pager show --no-color --pretty=medium %s',
       get_rev = 'rev-parse --short HEAD',
       get_header = 'log --color=never --pretty=format:FMT --no-show-signature HEAD -n 1',
       get_bodies = 'log --color=never --pretty=format:"===COMMIT_START===%h%n%s===BODY_START===%b" --no-show-signature HEAD@{1}...HEAD',

--- a/lua/packer/plugin_types/git.lua
+++ b/lua/packer/plugin_types/git.lua
@@ -200,6 +200,14 @@ local get_rev = function(plugin)
   end)
 end
 
+local split_messages = function(messages)
+  local lines = {}
+  for _, message in ipairs(messages) do
+    vim.list_extend(lines, vim.split(message, '\n'))
+  end
+  return lines
+end
+
 git.setup = function(plugin)
   local plugin_name = util.get_plugin_full_name(plugin)
   local install_to = plugin.install_path
@@ -503,7 +511,7 @@ git.setup = function(plugin)
       local diff_callbacks = { stdout = diff_onread, stderr = diff_onread }
       return await(jobs.run(diff_cmd, { capture_output = diff_callbacks, cwd = install_to, options = { env = git.job_env } }))
         :map_ok(function(_)
-          return callback(diff_info.messages)
+          return callback(split_messages(diff_info.messages))
         end)
         :map_err(function(err)
           return callback(nil, err)


### PR DESCRIPTION
If there is a range of commits, eg `00cba85..116a568` then the diff no longer only shows the diff of the first commit but of the whole range. Currently this shows the diff for each commit and not the total diff from the first to the last but that can be configured by the user with a different command.

@akinsho, I think you initially implemented this so maybe you'd be interested and I'm happy to hear any thoughts.