### PR TITLE
feat(display): allow not showing info by default when displaying results

### DIFF
--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -49,6 +49,7 @@ local config_defaults = {
   },
   display = {
     non_interactive = false,
+    compact = false,
     open_fn = nil,
     open_cmd = '65vnew',
     working_sym = '⟳',

--- a/lua/packer/display.lua
+++ b/lua/packer/display.lua
@@ -592,9 +592,16 @@ local display_mt = {
     for _, plugin_name in pairs(self.item_order) do
       local plugin_data = self.items[plugin_name]
       if plugin_data and plugin_data.spec.actual_update and #plugin_data.lines > 0 then
-        self:set_lines(line, line, plugin_data.lines)
-        line = line + #plugin_data.lines + 1
-        plugin_data.displayed = true
+        local next_line
+        if config.compact then
+          next_line = line + 1
+          plugin_data.displayed = false
+        else
+          self:set_lines(line, line, plugin_data.lines)
+          next_line = line + #plugin_data.lines + 1
+          plugin_data.displayed = true
+        end
+        line = next_line
       else
         line = line + 1
       end


### PR DESCRIPTION
This allows to opt-in for having all the infos closed by defaults in the final update results. They can still be opened as normal with `<CR>`.