### PR TITLE
fix: README bootstrap error (fixes #742)

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ if fn.empty(fn.glob(install_path)) > 0 then
 end
 
 return require('packer').startup(function(use)
-  use { 'wbthomason/packer.nvim' }
+  use 'wbthomason/packer.nvim'
   -- My plugins here
   -- use 'foo1/bar1.nvim'
   -- use 'foo2/bar2.nvim'

--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ if fn.empty(fn.glob(install_path)) > 0 then
 end
 
 return require('packer').startup(function(use)
+  use { 'wbthomason/packer.nvim' }
   -- My plugins here
   -- use 'foo1/bar1.nvim'
   -- use 'foo2/bar2.nvim'


### PR DESCRIPTION
Fixes bootstrap code in README.md which erroneously tries to clean the newly installed packer.nvim package when there are no packages listed in the `startup()` call.

Fixes #742