### PR TITLE
Fix: check if a plugin given as a requirement is a single-specification table

### DIFF
--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -270,7 +270,7 @@ manage = function(plugin_data)
     -- Handle single plugins given as strings or single plugin specs given as tables
     if
       type(plugin_spec.requires) == 'string'
-      or (type(plugin_spec.requires) == 'table' and #plugin_spec.requires == 1)
+      or (type(plugin_spec.requires) == 'table' and not vim.tbl_islist(plugin_spec.requires) and #plugin_spec.requires == 1)
     then
       plugin_spec.requires = { plugin_spec.requires }
     end

--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -267,7 +267,11 @@ manage = function(plugin_data)
   plugins[plugin_spec.short_name].url = util.remove_ending_git_url(plugin_spec.url)
 
   if plugin_spec.requires and config.ensure_dependencies then
-    if type(plugin_spec.requires) == 'string' then
+    -- Handle single plugins given as strings or single plugin specs given as tables
+    if
+      type(plugin_spec.requires) == 'string'
+      or (type(plugin_spec.requires) == 'table' and #plugin_spec.requires == 1)
+    then
       plugin_spec.requires = { plugin_spec.requires }
     end
     for _, req in ipairs(plugin_spec.requires) do


### PR DESCRIPTION
Should fix #1038 by adding a missing check for a possible `requires` case.

@glepnir, does this work for you?
