### PR TITLE
Fix: use vim.notify in packer.log

### DIFF
--- a/lua/packer/log.lua
+++ b/lua/packer/log.lua
@@ -99,8 +99,13 @@ log.new = function(config, standalone)
   local console_output = vim.schedule_wrap(function(level_config, info, nameupper, msg)
     local console_lineinfo = vim.fn.fnamemodify(info.short_src, ':t') .. ':' .. info.currentline
     local console_string = string.format('[%-6s%s] %s: %s', nameupper, os.date '%H:%M:%S', console_lineinfo, msg)
-
-    vim.notify(string.format([[[%s] %s]], config.plugin, console_string), vim.log.levels[level_config.name:upper()])
+    -- Heuristic to check for nvim-notify
+    local is_fancy_notify = type(vim.notify) == 'table'
+    vim.notify(
+      string.format([[%s%s]], is_fancy_notify and '' or ('[' .. config.plugin .. '] '), console_string),
+      vim.log.levels[level_config.name:upper()],
+      { title = config.plugin }
+    )
   end)
 
   local log_at_level = function(level, level_config, message_maker, ...)

--- a/lua/packer/log.lua
+++ b/lua/packer/log.lua
@@ -100,18 +100,7 @@ log.new = function(config, standalone)
     local console_lineinfo = vim.fn.fnamemodify(info.short_src, ':t') .. ':' .. info.currentline
     local console_string = string.format('[%-6s%s] %s: %s', nameupper, os.date '%H:%M:%S', console_lineinfo, msg)
 
-    if config.highlights and level_config.hl then
-      vim.cmd(string.format('echohl %s', level_config.hl))
-    end
-
-    local split_console = vim.split(console_string, '\n')
-    for _, v in ipairs(split_console) do
-      vim.cmd(string.format([[echom "[%s] %s"]], config.plugin, vim.fn.escape(v, '"')))
-    end
-
-    if config.highlights and level_config.hl then
-      vim.cmd 'echohl NONE'
-    end
+    vim.notify(string.format([[[%s] %s]], config.plugin, console_string), vim.log.levels[level_config.name:upper()])
   end)
 
   local log_at_level = function(level, level_config, message_maker, ...)

--- a/lua/packer/snapshot.lua
+++ b/lua/packer/snapshot.lua
@@ -196,7 +196,6 @@ snapshot.delete = function(snapshot_name)
   if snapshot_path == nil then
     local warn = fmt("Snapshot '%s' is wrong or doesn't exist", snapshot_name)
     log.warn(warn)
-    vim.notify(warn, vim.log.levels.WARN, { title = 'packer.nvim' })
     return
   end
 
@@ -204,11 +203,9 @@ snapshot.delete = function(snapshot_name)
   if vim.loop.fs_unlink(snapshot_path) then
     local info = 'Deleted ' .. snapshot_path
     log.info(info)
-    vim.notify(info, vim.log.levels.INFO, { title = 'packer.nvim' })
   else
     local warn = "Couldn't delete " .. snapshot_path
     log.warn(warn)
-    vim.notify(warn, vim.log.levels.WARN, { title = 'packer.nvim' })
   end
 end
 


### PR DESCRIPTION
`vim.notify` exists now, and is preferable to the old `echom` method of logging. Some parts of `packer` used `vim.notify` directly, while some used `log`. This led to inconsistent output.

This PR makes the `log` API use `vim.notify` internally, and moves manual uses of `vim.notify` to use the `log` API.

- Use vim.notify instead of echom to log to console
- Move manual uses of vim.notify to use the log API
