### PR TITLE
fix(update): error message when unknown plugin is provided

### DIFF
--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -521,6 +521,9 @@ packer.update = function(...)
     log.debug 'Gathering update tasks'
     await(a.main)
     update_tasks, display_win = update(plugins, installed_plugins, display_win, results, opts)
+    if update_tasks == nil then
+      return
+    end
     vim.list_extend(tasks, update_tasks)
     log.debug 'Gathering luarocks tasks'
     local luarocks_ensure_task = luarocks.ensure(rocks, results, display_win)
@@ -602,6 +605,9 @@ packer.sync = function(...)
     log.debug 'Gathering update tasks'
     await(a.main)
     update_tasks, display_win = update(plugins, installed_plugins, display_win, results, opts)
+    if update_tasks == nil then
+      return
+    end
     vim.list_extend(tasks, update_tasks)
     log.debug 'Gathering luarocks tasks'
     local luarocks_clean_task = luarocks.clean(rocks, results, display_win)

--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -527,13 +527,16 @@ packer.update = function(...)
     if luarocks_ensure_task ~= nil then
       table.insert(tasks, luarocks_ensure_task)
     end
+
+    if #tasks == 0 then
+      return
+    end
+
     table.insert(tasks, 1, function()
       return not display.status.running
     end)
     table.insert(tasks, 1, config.max_jobs and config.max_jobs or (#tasks - 1))
-    if #tasks > 0 then
-      display_win:update_headline_message('updating ' .. #tasks - 2 .. ' / ' .. #tasks - 2 .. ' plugins')
-    end
+    display_win:update_headline_message('updating ' .. #tasks - 2 .. ' / ' .. #tasks - 2 .. ' plugins')
     log.debug 'Running tasks'
     a.interruptible_wait_pool(unpack(tasks))
     local install_paths = {}
@@ -553,9 +556,7 @@ packer.update = function(...)
     plugin_utils.update_helptags(install_paths)
     plugin_utils.update_rplugins()
     local delta = string.gsub(vim.fn.reltimestr(vim.fn.reltime(start_time)), ' ', '')
-    if #tasks > 0 then
-      display_win:final_results(results, delta, opts)
-    end
+    display_win:final_results(results, delta, opts)
     packer.on_complete()
   end)()
 end
@@ -612,18 +613,21 @@ packer.sync = function(...)
     if luarocks_clean_task ~= nil then
       table.insert(tasks, luarocks_clean_task)
     end
+
     local luarocks_ensure_task = luarocks.ensure(rocks, results, display_win)
     if luarocks_ensure_task ~= nil then
       table.insert(tasks, luarocks_ensure_task)
     end
+    if #tasks == 0 then
+      return
+    end
+
     table.insert(tasks, 1, function()
       return not display.status.running
     end)
     table.insert(tasks, 1, config.max_jobs and config.max_jobs or (#tasks - 1))
     log.debug 'Running tasks'
-    if #tasks > 0 then
-      display_win:update_headline_message('syncing ' .. #tasks - 2 .. ' / ' .. #tasks - 2 .. ' plugins')
-    end
+    display_win:update_headline_message('syncing ' .. #tasks - 2 .. ' / ' .. #tasks - 2 .. ' plugins')
     a.interruptible_wait_pool(unpack(tasks))
     local install_paths = {}
     for plugin_name, r in pairs(results.installs) do
@@ -645,9 +649,7 @@ packer.sync = function(...)
     plugin_utils.update_helptags(install_paths)
     plugin_utils.update_rplugins()
     local delta = string.gsub(vim.fn.reltimestr(vim.fn.reltime(start_time)), ' ', '')
-    if #tasks > 0 then
-      display_win:final_results(results, delta, opts)
-    end
+    display_win:final_results(results, delta, opts)
     packer.on_complete()
   end)()
 end

--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -465,7 +465,7 @@ end
 -- Filter out options specified as the first argument to update or sync
 -- returns the options table and the plugin names
 local filter_opts_from_plugins = function(...)
-  local args = {...}
+  local args = { ... }
   local opts = {}
   if not vim.tbl_isempty(args) then
     local first = args[1]
@@ -474,7 +474,7 @@ local filter_opts_from_plugins = function(...)
       opts = first
     elseif first == '--preview' then
       table.remove(args, 1)
-      opts = {preview_updates = true}
+      opts = { preview_updates = true }
     end
   end
   if opts.preview_updates == nil and config.preview_updates then

--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -521,9 +521,6 @@ packer.update = function(...)
     log.debug 'Gathering update tasks'
     await(a.main)
     update_tasks, display_win = update(plugins, installed_plugins, display_win, results, opts)
-    if update_tasks == nil then
-      return
-    end
     vim.list_extend(tasks, update_tasks)
     log.debug 'Gathering luarocks tasks'
     local luarocks_ensure_task = luarocks.ensure(rocks, results, display_win)
@@ -534,7 +531,9 @@ packer.update = function(...)
       return not display.status.running
     end)
     table.insert(tasks, 1, config.max_jobs and config.max_jobs or (#tasks - 1))
-    display_win:update_headline_message('updating ' .. #tasks - 2 .. ' / ' .. #tasks - 2 .. ' plugins')
+    if #tasks > 0 then
+      display_win:update_headline_message('updating ' .. #tasks - 2 .. ' / ' .. #tasks - 2 .. ' plugins')
+    end
     log.debug 'Running tasks'
     a.interruptible_wait_pool(unpack(tasks))
     local install_paths = {}
@@ -554,7 +553,9 @@ packer.update = function(...)
     plugin_utils.update_helptags(install_paths)
     plugin_utils.update_rplugins()
     local delta = string.gsub(vim.fn.reltimestr(vim.fn.reltime(start_time)), ' ', '')
-    display_win:final_results(results, delta, opts)
+    if #tasks > 0 then
+      display_win:final_results(results, delta, opts)
+    end
     packer.on_complete()
   end)()
 end
@@ -605,9 +606,6 @@ packer.sync = function(...)
     log.debug 'Gathering update tasks'
     await(a.main)
     update_tasks, display_win = update(plugins, installed_plugins, display_win, results, opts)
-    if update_tasks == nil then
-      return
-    end
     vim.list_extend(tasks, update_tasks)
     log.debug 'Gathering luarocks tasks'
     local luarocks_clean_task = luarocks.clean(rocks, results, display_win)
@@ -623,7 +621,9 @@ packer.sync = function(...)
     end)
     table.insert(tasks, 1, config.max_jobs and config.max_jobs or (#tasks - 1))
     log.debug 'Running tasks'
-    display_win:update_headline_message('syncing ' .. #tasks - 2 .. ' / ' .. #tasks - 2 .. ' plugins')
+    if #tasks > 0 then
+      display_win:update_headline_message('syncing ' .. #tasks - 2 .. ' / ' .. #tasks - 2 .. ' plugins')
+    end
     a.interruptible_wait_pool(unpack(tasks))
     local install_paths = {}
     for plugin_name, r in pairs(results.installs) do
@@ -645,7 +645,9 @@ packer.sync = function(...)
     plugin_utils.update_helptags(install_paths)
     plugin_utils.update_rplugins()
     local delta = string.gsub(vim.fn.reltimestr(vim.fn.reltime(start_time)), ' ', '')
-    display_win:final_results(results, delta, opts)
+    if #tasks > 0 then
+      display_win:final_results(results, delta, opts)
+    end
     packer.on_complete()
   end)()
 end

--- a/lua/packer/update.lua
+++ b/lua/packer/update.lua
@@ -116,9 +116,8 @@ local function do_update(_, plugins, update_plugins, display_win, results, opts)
     local plugin = plugins[v]
     if plugin == nil then
       log.error(fmt('Unknown plugin %s', v))
-      return
     end
-    if not plugin.frozen then
+    if plugin and not plugin.frozen then
       if display_win == nil then
         display_win = display.open(config.display.open_fn or config.display.open_cmd)
       end

--- a/lua/packer/update.lua
+++ b/lua/packer/update.lua
@@ -115,7 +115,7 @@ local function do_update(_, plugins, update_plugins, display_win, results, opts)
   for _, v in ipairs(update_plugins) do
     local plugin = plugins[v]
     if plugin == nil then
-      log.error(fmt('Unknown plugin %s', v))
+      log.error(fmt('Unknown plugin: %s', v))
     end
     if plugin and not plugin.frozen then
       if display_win == nil then

--- a/lua/packer/update.lua
+++ b/lua/packer/update.lua
@@ -114,6 +114,10 @@ local function do_update(_, plugins, update_plugins, display_win, results, opts)
   local tasks = {}
   for _, v in ipairs(update_plugins) do
     local plugin = plugins[v]
+    if plugin == nil then
+      log.error(fmt('Unknown plugin %s', v))
+      return
+    end
     if not plugin.frozen then
       if display_win == nil then
         display_win = display.open(config.display.open_fn or config.display.open_cmd)


### PR DESCRIPTION
Currently if you do eg `PackerUpdate foobar` and there is no plugin `foobar` you get a bit cryptic error about accessing a `nil` value. This just adds a more clear error message.