### PR TITLE
Pass hook name into plugin run functions

### DIFF
--- a/lua/packer/install.lua
+++ b/lua/packer/install.lua
@@ -17,7 +17,7 @@ local function install_plugin(plugin, display_win, results)
     -- TODO: If the user provided a custom function as an installer, we would like to use pcall
     -- here. Need to figure out how that integrates with async code
     local r = await(plugin.installer(display_win))
-    r = r:and_then(await, plugin_utils.post_update_hook(plugin, display_win))
+    r = r:and_then(await, plugin_utils.post_install_hook(plugin, display_win))
     if r.ok then
       display_win:task_succeeded(plugin_name, 'installed')
       log.debug('Installed ' .. plugin_name)

--- a/lua/packer/plugin_utils.lua
+++ b/lua/packer/plugin_utils.lua
@@ -208,7 +208,7 @@ plugin_utils.load_plugin = function(plugin)
   end
 end
 
-plugin_utils.post_update_hook = function(plugin, disp)
+local run_hook = function(plugin, disp, hook_name)
   local plugin_name = util.get_plugin_full_name(plugin)
   return a.sync(function()
     if plugin.run or not plugin.opt then
@@ -220,14 +220,14 @@ plugin_utils.post_update_hook = function(plugin, disp)
       if type(plugin.run) ~= 'table' then
         plugin.run = { plugin.run }
       end
-      disp:task_update(plugin_name, 'running post update hooks...')
+      disp:task_update(plugin_name, 'running ' .. hook_name .. ' hooks...')
       local hook_result = result.ok()
       for _, task in ipairs(plugin.run) do
         if type(task) == 'function' then
-          local success, err = pcall(task, plugin, disp)
+          local success, err = pcall(task, plugin, disp, hook_name)
           if not success then
             return result.err {
-              msg = 'Error running post update hook: ' .. vim.inspect(err),
+              msg = 'Error running ' .. hook_name .. ' hook: ' .. vim.inspect(err),
             }
           end
         elseif type(task) == 'string' then
@@ -250,7 +250,7 @@ plugin_utils.post_update_hook = function(plugin, disp)
             hook_result = await(jobs.run(cmd, { capture_output = hook_callbacks, cwd = plugin.install_path })):map_err(
               function(err)
                 return {
-                  msg = string.format('Error running post update hook: %s', table.concat(hook_output.output, '\n')),
+                  msg = string.format('Error running ' .. hook_name .. ' hook: %s', table.concat(hook_output.output, '\n')),
                   data = err,
                 }
               end
@@ -266,7 +266,7 @@ plugin_utils.post_update_hook = function(plugin, disp)
 
           hook_result = await(jobs.run(task)):map_err(function(err)
             return {
-              msg = string.format('Error running post update hook: %s', vim.inspect(err)),
+              msg = string.format('Error running ' .. hook_name .. ' hook: %s', vim.inspect(err)),
               data = err,
             }
           end)
@@ -282,6 +282,14 @@ plugin_utils.post_update_hook = function(plugin, disp)
       return result.ok()
     end
   end)
+end
+
+plugin_utils.post_install_hook = function(plugin, disp)
+  return run_hook(plugin, disp, 'post_install')
+end
+
+plugin_utils.post_update_hook = function(plugin, disp)
+  return run_hook(plugin, disp, 'post_update')
 end
 
 return plugin_utils


### PR DESCRIPTION
This PR adds a third argument the plugin run function, allowing the user to easily run code only on install or update of a plugin.

It should be backwards compatible as existing functions that only accept 2 arguments will still work as before.