### PR TITLE
feat(lazy): add lazy loader

### DIFF
--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -1,6 +1,9 @@
 -- TODO: Performance analysis/tuning
 -- TODO: Merge start plugins?
-local util = require 'packer.util'
+local lazy = require 'packer.lazy'
+local util = lazy.require 'packer.util'
+---@module 'packer.async'
+local a = lazy.require 'packer.async'
 
 local join_paths = util.join_paths
 local stdpath = vim.fn.stdpath
@@ -348,7 +351,6 @@ end
 -- Finds plugins present in the `packer` package but not in the managed set
 packer.clean = function(results)
   local plugin_utils = require_and_configure 'plugin_utils'
-  local a = require 'packer.async'
   local async = a.sync
   local await = a.wait
   local luarocks = require_and_configure 'luarocks'
@@ -379,7 +381,6 @@ packer.install = function(...)
   local log = require_and_configure 'log'
   log.debug 'packer.install: requiring modules'
   local plugin_utils = require_and_configure 'plugin_utils'
-  local a = require 'packer.async'
   local async = a.sync
   local await = a.wait
   local luarocks = require_and_configure 'luarocks'
@@ -452,7 +453,6 @@ packer.update = function(...)
   local log = require_and_configure 'log'
   log.debug 'packer.update: requiring modules'
   local plugin_utils = require_and_configure 'plugin_utils'
-  local a = require 'packer.async'
   local async = a.sync
   local await = a.wait
   local luarocks = require_and_configure 'luarocks'
@@ -527,7 +527,6 @@ packer.sync = function(...)
   local log = require_and_configure 'log'
   log.debug 'packer.sync: requiring modules'
   local plugin_utils = require_and_configure 'plugin_utils'
-  local a = require 'packer.async'
   local async = a.sync
   local await = a.wait
   local luarocks = require_and_configure 'luarocks'
@@ -604,7 +603,7 @@ packer.sync = function(...)
 end
 
 packer.status = function()
-  local async = require('packer.async').sync
+  local async = a.sync
   local display = require_and_configure 'display'
   local log = require_and_configure 'log'
   manage_all_plugins()
@@ -679,7 +678,6 @@ end
 packer.compile = function(raw_args, move_plugins)
   local compile = require_and_configure 'compile'
   local log = require_and_configure 'log'
-  local a = require 'packer.async'
   local async = a.sync
   local await = a.wait
   -- TODO: check if the user wants any compilation at all via a new config variable
@@ -745,7 +743,7 @@ packer.compile = function(raw_args, move_plugins)
 end
 
 packer.profile_output = function()
-  local async = require('packer.async').sync
+  local async = a.sync
   local display = require_and_configure 'display'
   local log = require_and_configure 'log'
 
@@ -812,8 +810,7 @@ end
 ---Snapshots installed plugins
 ---@param snapshot_name string absolute path or just a snapshot name
 packer.snapshot = function(snapshot_name, ...)
-  local async = require('packer.async').sync
-  local await = require('packer.async').wait
+  local async, await = a.sync, a.wait
   local snapshot = require 'packer.snapshot'
   local log = require_and_configure 'log'
   local args = { ... }
@@ -885,10 +882,8 @@ end
 ---otherwise all the plugins will be rolled back
 packer.rollback = function(snapshot_name, ...)
   local args = { ... }
-  local a = require 'packer.async'
   local async = a.sync
   local await = a.wait
-  local wait_all = a.wait_all
   local snapshot = require 'packer.snapshot'
   local log = require_and_configure 'log'
   local fmt = string.format

--- a/lua/packer/async.lua
+++ b/lua/packer/async.lua
@@ -1,5 +1,8 @@
 -- Adapted from https://ms-jpq.github.io/neovim-async-tutorial/
-local log = require 'packer.log'
+
+local lazy = require 'packer.lazy'
+---@module 'packer.log'
+local log = lazy.require 'packer.log'
 local yield = coroutine.yield
 local resume = coroutine.resume
 local thread_create = coroutine.create

--- a/lua/packer/clean.lua
+++ b/lua/packer/clean.lua
@@ -1,8 +1,11 @@
-local plugin_utils = require 'packer.plugin_utils'
-local a = require 'packer.async'
-local display = require 'packer.display'
-local log = require 'packer.log'
-local util = require 'packer.util'
+local lazy = require 'packer.lazy'
+
+---@module 'packer.async'
+local a = lazy.require 'packer.async'
+---@module 'packer.display'
+local display = lazy.require 'packer.display'
+---@module 'packer.log'
+local log = lazy.require 'packer.log'
 
 local await = a.wait
 local async = a.sync

--- a/lua/packer/config.lua
+++ b/lua/packer/config.lua
@@ -1,6 +1,8 @@
 --- Configuration
 
-local path_utils = require 'packer.path'
+local lazy = require 'packer.lazy'
+---@module 'packer.path'
+local path_utils = lazy.require 'packer.path'
 local stdpath = vim.fn.stdpath
 local join_paths = path_utils.join_paths
 local path_separator = path_utils.path_separator

--- a/lua/packer/display.lua
+++ b/lua/packer/display.lua
@@ -1,7 +1,12 @@
+local lazy = require 'packer.lazy'
+---@module 'packer.log'
+local log = lazy.require 'packer.log'
+---@module 'packer.async'
+local a = lazy.require 'packer.async'
+---@module 'packer.plugin_utils'
+local plugin_utils = lazy.require 'packer.plugin_utils'
+
 local api = vim.api
-local log = require 'packer.log'
-local a = require 'packer.async'
-local plugin_utils = require 'packer.plugin_utils'
 local fmt = string.format
 
 local in_headless = #api.nvim_list_uis() == 0

--- a/lua/packer/handlers.lua
+++ b/lua/packer/handlers.lua
@@ -78,7 +78,8 @@ local handler_names = {
 
 -- Default handler implementations
 
-local profile = require 'packer.profile'
+local lazy = require 'packer.lazy'
+local profile = lazy.require 'packer.profile'
 local timed_run = profile.timed_run
 local timed_packadd = profile.timed_packadd
 local timed_load = profile.timed_load

--- a/lua/packer/lazy.lua
+++ b/lua/packer/lazy.lua
@@ -1,0 +1,21 @@
+local lazy = {}
+
+--- Require on index.
+---
+--- Will only require the module after the first index of a module.
+--- Only works for modules that export a table.
+---@param require_path string
+---@return table
+lazy.require = function(require_path)
+  return setmetatable({}, {
+    __index = function(_, key)
+      return require(require_path)[key]
+    end,
+
+    __newindex = function(_, key, value)
+      require(require_path)[key] = value
+    end,
+  })
+end
+
+return lazy

--- a/lua/packer/plugin_utils.lua
+++ b/lua/packer/plugin_utils.lua
@@ -1,8 +1,14 @@
-local a = require 'packer.async'
-local jobs = require 'packer.jobs'
-local util = require 'packer.util'
-local result = require 'packer.result'
-local log = require 'packer.log'
+local lazy = require 'packer.lazy'
+---@module 'packer.async'
+local a = lazy.require 'packer.async'
+---@module 'packer.jobs'
+local jobs = lazy.require 'packer.jobs'
+---@module 'packer.util'
+local util = lazy.require 'packer.util'
+---@module 'packer.result'
+local result = lazy.require 'packer.result'
+---@module 'packer.log'
+local log = lazy.require 'packer.log'
 
 local await = a.wait
 
@@ -183,12 +189,10 @@ plugin_utils.load_plugin = function(plugin)
     vim.cmd('packadd ' .. plugin.short_name)
   else
     vim.o.runtimepath = vim.o.runtimepath .. ',' .. plugin.install_path
-    for _, pat in
-      ipairs {
-        table.concat({ 'plugin', '**/*.vim' }, util.get_separator()),
-        table.concat({ 'after', 'plugin', '**/*.vim' }, util.get_separator()),
-      }
-    do
+    for _, pat in ipairs {
+      table.concat({ 'plugin', '**/*.vim' }, util.get_separator()),
+      table.concat({ 'after', 'plugin', '**/*.vim' }, util.get_separator()),
+    } do
       local path = util.join_paths(plugin.install_path, pat)
       local glob_ok, files = pcall(vim.fn.glob, path, false, true)
       if not glob_ok then

--- a/lua/packer/update.lua
+++ b/lua/packer/update.lua
@@ -1,9 +1,16 @@
-local util = require 'packer.util'
-local result = require 'packer.result'
-local display = require 'packer.display'
-local a = require 'packer.async'
-local log = require 'packer.log'
-local plugin_utils = require 'packer.plugin_utils'
+local lazy = require 'packer.lazy'
+---@module 'packer.util'
+local util = lazy.require 'packer.util'
+---@module 'packer.result'
+local result = lazy.require 'packer.result'
+---@module 'packer.display'
+local display = lazy.require 'packer.display'
+---@module 'packer.async'
+local a = lazy.require 'packer.async'
+---@module 'packer.log'
+local log = lazy.require 'packer.log'
+---@module 'packer.plugin_utils'
+local plugin_utils = lazy.require 'packer.plugin_utils'
 
 local fmt = string.format
 local async = a.sync


### PR DESCRIPTION
This PR adds in a lazy loading module for packer which is entirely based on TJ's project https://github.com/tjdevries/lazy.nvim. It also adds in `@module` syntax for the lazy loaded modules so that whilst using `sumneko` lsp these imports still have the correct types.

It should reduce the defer the cost of requiring modules till they are actually used which hopefully will improve startup times for packer.

Ideally all imports should now use this and can then be added at the top of the file rather than several adhoc requires inside of functions, the added value of which is that you can see at a glance what modules a module depends on