### PR TITLE
Fix #1084: prompt_user sets bufhidden to wipe

### DIFF
--- a/lua/packer/display.lua
+++ b/lua/packer/display.lua
@@ -85,6 +85,7 @@ local function prompt_user(headline, body, callback)
       string.rep(' ', pad_width) .. headline .. string.rep(' ', pad_width), ''
     }, body))
   api.nvim_buf_set_option(buf, 'modifiable', false)
+  api.nvim_buf_set_option(buf, 'hidden', 'wipe')
   local opts = {
     relative = 'editor',
     width = width,


### PR DESCRIPTION
Simple fix to stop packer from leaving unlisted buffers polluting the bufferlist