### PR TITLE
Return snapshot async fn so it can be awaited

### DIFF
--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -902,7 +902,7 @@ packer.snapshot = function(snapshot_name, ...)
     )
   end
 
-  async(function()
+  return async(function()
     if write_snapshot then
       await(snapshot.create(snapshot_path, target_plugins))
         :map_ok(function(ok)


### PR DESCRIPTION
Exactly as it says on the can. I'd like to do something like:

```lua
await(packer.snapshot(path, plugins))
-- then do some other stuff with the generated snapshot
```