### PR TITLE
feat: use config from `_G.packer_plugins` in `packer_compiled.lua`

### DIFF
--- a/lua/packer/compile.lua
+++ b/lua/packer/compile.lua
@@ -197,6 +197,9 @@ end
 local function make_try_loadstring(item, chunk, name)
   local bytecode = string.dump(item, true)
   local executable_string = 'try_loadstring(' .. vim.inspect(bytecode) .. ', "' .. chunk .. '", "' .. name .. '")'
+  if chunk == 'config' then
+    executable_string = ('try_loadstring(_G.packer_plugins["%s"].%s[1], "%s", "%s")'):format(name, chunk, chunk, name)
+  end
   return executable_string, bytecode
 end
 


### PR DESCRIPTION
Since plugins's config is in `config` field of `_G.packer_plugins`, we could use it directly. Otherwise, before this, the compiled config string could be appear twice in  `packer_compiled.lua`.

Result:
```lua
-- Config for: monokai.nvim
time([[Config for monokai.nvim]], true)
try_loadstring(_G.packer_plugins["monokai.nvim"].config[1], "config", "monokai.nvim")
time([[Config for monokai.nvim]], false)
```