### PR TITLE
Fix incorrect numbering of plugins in dialogs

### DIFF
--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -536,7 +536,7 @@ packer.update = function(...)
       return not display.status.running
     end)
     table.insert(tasks, 1, config.max_jobs and config.max_jobs or (#tasks - 1))
-    display_win:update_headline_message('updating ' .. #tasks - 2 .. ' / ' .. #tasks - 2 .. ' plugins')
+    display_win:update_headline_message('updating ' .. #tasks - 3 .. ' / ' .. #tasks - 3 .. ' plugins')
     log.debug 'Running tasks'
     a.interruptible_wait_pool(unpack(tasks))
     local install_paths = {}

--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -440,7 +440,7 @@ packer.install = function(...)
       end)
       table.insert(tasks, 1, config.max_jobs and config.max_jobs or (#tasks - 1))
       log.debug 'Running tasks'
-      display_win:update_headline_message('installing ' .. #tasks - 2 .. ' / ' .. #tasks - 2 .. ' plugins')
+      display_win:update_headline_message('installing ' .. #tasks - 3 .. ' / ' .. #tasks - 3 .. ' plugins')
       a.interruptible_wait_pool(unpack(tasks))
       local install_paths = {}
       for plugin_name, r in pairs(results.installs) do
@@ -627,7 +627,7 @@ packer.sync = function(...)
     end)
     table.insert(tasks, 1, config.max_jobs and config.max_jobs or (#tasks - 1))
     log.debug 'Running tasks'
-    display_win:update_headline_message('syncing ' .. #tasks - 2 .. ' / ' .. #tasks - 2 .. ' plugins')
+    display_win:update_headline_message('syncing ' .. #tasks - 4 .. ' / ' .. #tasks - 4 .. ' plugins')
     a.interruptible_wait_pool(unpack(tasks))
     local install_paths = {}
     for plugin_name, r in pairs(results.installs) do


### PR DESCRIPTION
Packer is currently showing the wrong number of plugins during sync, install, and update dialogs. X plugins are shown on `PackerStatus` but `PackerSync` et al. show the wrong number. This resolves issue #1086 . 