### PR TITLE
fix: force Git fetch during updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,9 +314,9 @@ default configuration values (and structure of the configuration table) are:
   git = {
     cmd = 'git', -- The base command for git operations
     subcommands = { -- Format strings for git subcommands
-      update         = 'pull --ff-only --progress --rebase=false',
+      update         = 'pull --ff-only --progress --rebase=false --force',
       install        = 'clone --depth %i --no-single-branch --progress',
-      fetch          = 'fetch --depth 999999 --progress',
+      fetch          = 'fetch --depth 999999 --progress --force',
       checkout       = 'checkout %s --',
       update_branch  = 'merge --ff-only @{u}',
       current_branch = 'branch --show-current',

--- a/doc/packer.txt
+++ b/doc/packer.txt
@@ -215,9 +215,9 @@ default values: >
     git = {
       cmd = 'git', -- The base command for git operations
       subcommands = { -- Format strings for git subcommands
-        update         = 'pull --ff-only --progress --rebase=false',
+        update         = 'pull --ff-only --progress --rebase=false --force',
         install        = 'clone --depth %i --no-single-branch --progress',
-        fetch          = 'fetch --depth 999999 --progress',
+        fetch          = 'fetch --depth 999999 --progress --force',
         checkout       = 'checkout %s --',
         update_branch  = 'merge --ff-only @{u}',
         current_branch = 'branch --show-current',

--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -27,10 +27,10 @@ local config_defaults = {
     mark_breaking_changes = true,
     cmd = 'git',
     subcommands = {
-      update = 'pull --ff-only --progress --rebase=false',
+      update = 'pull --ff-only --progress --rebase=false --force',
       update_head = 'merge FETCH_HEAD',
       install = 'clone --depth %i --no-single-branch --progress',
-      fetch = 'fetch --depth 999999 --progress',
+      fetch = 'fetch --depth 999999 --progress --force',
       checkout = 'checkout %s --',
       update_branch = 'merge --ff-only @{u}',
       current_branch = 'rev-parse --abbrev-ref HEAD',


### PR DESCRIPTION
Fixes #1100 

I believe `--force` is a sensible default in the context of `packer` updates. In most cases, users don't care about things such as force-pushed tags, and simply want packer to pull whatever Git ref was indicated in their config.