### PR TITLE
fix(interactive): let interactive mode work for remote clients attached to headless instances

### DIFF
--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -130,9 +130,6 @@ packer.init = function(user_config)
   config.pack_dir = join_paths(config.package_root, config.plugin_package)
   config.opt_dir = join_paths(config.pack_dir, 'opt')
   config.start_dir = join_paths(config.pack_dir, 'start')
-  if #vim.api.nvim_list_uis() == 0 then
-    config.display.non_interactive = true
-  end
 
   local plugin_utils = require_and_configure 'plugin_utils'
   plugin_utils.ensure_dirs()

--- a/lua/packer/display.lua
+++ b/lua/packer/display.lua
@@ -4,7 +4,9 @@ local a = require 'packer.async'
 local plugin_utils = require 'packer.plugin_utils'
 local fmt = string.format
 
-local in_headless = #api.nvim_list_uis() == 0
+local function interactive(config)
+  return not config.non_interactive and #api.nvim_list_uis() > 0
+end
 
 -- Temporary wrappers to compensate for the updated extmark API, until most people have updated to
 -- the latest HEAD (2020-09-04)
@@ -140,7 +142,7 @@ local default_keymap_display_order = {
 
 --- Utility function to prompt a user with a question in a floating window
 local function prompt_user(headline, body, callback)
-  if config.non_interactive then
+  if not interactive(config) then
     callback(true)
     return
   end
@@ -961,7 +963,7 @@ display.open = function(opener)
   local disp = setmetatable({}, display_mt)
   disp.marks = {}
   disp.plugins = {}
-  disp.interactive = not config.non_interactive and not in_headless
+  disp.interactive = interactive(config)
 
   if disp.interactive then
     if type(opener) == 'string' then


### PR DESCRIPTION
Fixes #1112

Instead of calculating whether the nvim instance is headless at startup and caching that (both in the config.non_interactive flag as well as a local var in the display module), just recalculate whether nvim is interactive whenever it needs to make the decision (when displaying windows or prompting the user).