### PR TITLE
README.md: update plugin author username

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ return require('packer').startup(function(use)
   use 'wbthomason/packer.nvim'
 
   -- Simple plugins can be specified as strings
-  use '9mm/vim-closer'
+  use 'rstacruz/vim-closer'
 
   -- Lazy loading:
   -- Load on specific commands


### PR DESCRIPTION
User `9mm` has changed their username on github to `rstacruz` which means the line `use '9mm/vim-closer'` in quickstart will throw an error as `github.com/9mm/vim-closer` no longer exists.