### PR TITLE
feat: rework startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,10 +165,11 @@ require('packer').add{
 The following is a more in-depth explanation of `packer`'s features and use.
 
 ### The `setup` and `add` functions
-`packer` provides`packer.add(spec)`, which is used in the above examples.
+`packer` provides`packer.add(spec)`, which is used in the above examples
+where `spec` is a table specifying a single or multiple plugins.
 
 ### Custom Initialization
-`packer.setup()` can be used to provide custom configuration.
+`packer.setup()` can be used to provide custom configuration (note that this is optional).
 The default configuration values (and structure of the configuration table) are:
 
 ```lua

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Differences:
 3. [Quickstart](#quickstart)
 4. [Bootstrapping](#bootstrapping)
 5. [Usage](#usage)
-    1. [The startup function](#the-startup-function)
+    1. [The setup and add functions](#the-setup-and-add-function)
     2. [Custom Initialization](#custom-initialization)
     3. [Specifying Plugins](#specifying-plugins)
     4. [Performing plugin management operations](#performing-plugin-management-operations)
@@ -30,7 +30,7 @@ Differences:
 - Support for local plugins
 
 ## Requirements
-- **You need to be running Neovim v0.7.0+**
+- **You need to be running Neovim v0.8.0+**
 - If you are on Windows 10, you need developer mode enabled in order to use local plugins (creating
   symbolic links requires admin privileges on Windows - credit to @TimUntersberger for this note)
 
@@ -57,9 +57,9 @@ Then you can write your plugin specification in Lua, e.g. (in `~/.config/nvim/lu
 ```lua
 -- This file can be loaded by calling `lua require('plugins')` from your init.vim
 
-require('packer').startup({
+require('packer').add{
   -- Packer can manage itself
-  'lewis6991/packer.nvim';
+  'wbthomason/packer.nvim';
 
   -- Simple plugins can be specified as strings
   '9mm/vim-closer';
@@ -106,12 +106,12 @@ require('packer').startup({
   { 'lewis6991/gitsigns.nvim',
     config = function()
       require('gitsigns').setup()
-      end
+    end
   };
-})
+}
 ```
 
-`packer` provides the following commands after you've run and configured `packer` with `require('packer').startup(...)`:
+`packer` provides the following commands.
 
 ```vim
 " Remove any disabled or unused plugins
@@ -151,32 +151,28 @@ end
 
 local packer_bootstrap = ensure_packer()
 
-require('packer').startup{{
+require('packer').add{
   'wbthomason/packer.nvim';
   -- My plugins here
   -- 'foo1/bar1.nvim';
   -- 'foo2/bar2.nvim';
 
-}}
+}
 ```
 
 ## Usage
 
 The following is a more in-depth explanation of `packer`'s features and use.
 
-### The `startup` function
-`packer` provides `packer.startup(spec)`, which is used in the above examples.
-
-`startup` is a convenience function for simple setup and can be invoked as follows:
-- `spec` must be a table with another table as its first element and config overrides as another element:
-  `packer.startup({ 'tjdevries/colorbuddy.vim'}, config = { ... }})`
+### The `setup` and `add` functions
+`packer` provides`packer.add(spec)`, which is used in the above examples.
 
 ### Custom Initialization
-You may pass a table of configuration values to `packer.startup()` to customize its operation. The
-default configuration values (and structure of the configuration table) are:
+`packer.setup()` can be used to provide custom configuration.
+The default configuration values (and structure of the configuration table) are:
+
 ```lua
-require('packer').startup{{...}, config = {
-  ensure_dependencies = true, -- Should packer install plugin dependencies?
+require('packer').setup{
   package_root        = util.join_paths(vim.fn.stdpath('data'), 'site', 'pack'),
   plugin_package      = 'packer', -- The default package for plugins
   max_jobs            = nil, -- Limit the number of simultaneous jobs. nil means no limit
@@ -184,18 +180,12 @@ require('packer').startup{{...}, config = {
   preview_updates     = false, -- If true, always preview updates before choosing which plugins to update, same as `PackerUpdate --preview`.
   git = {
     cmd = 'git', -- The base command for git operations
-    subcommands = { -- Format strings for git subcommands
-      diff_fmt = '%%h %%s (%%cr)',
-    },
     depth = 1, -- Git clone depth
     clone_timeout = 60, -- Timeout, in seconds, for git clones
     default_url_format = 'https://github.com/%s' -- Lua format string used for "aaa/bbb" style plugins
   },
   display = {
     non_interactive = false, -- If true, disable display windows for all operations
-    compact         = false, -- If true, fold updates results by default
-    open_fn         = nil, -- An optional function to open a window for packer's display
-    open_cmd        = '65vnew \\[packer\\]', -- An optional command to open a window for packer's display
     working_sym     = '⟳', -- The symbol for a plugin being installed/updated
     error_sym       = '✗', -- The symbol for a plugin with an error in installation/updating
     done_sym        = '✓', -- The symbol for a plugin which has completed installation/updating
@@ -215,7 +205,7 @@ require('packer').startup{{...}, config = {
   },
   log = { level = 'warn' }, -- The default print log level. One of: "trace", "debug", "info", "warn", "error", "fatal".
   autoremove = false, -- Remove disabled or unused plugins without prompting the user
-}}
+}
 ```
 
 ### Specifying plugins
@@ -288,8 +278,6 @@ treated as a plugin location string and the corresponding plugin is added to the
 
 If `requires` is a list, it is treated as a list of plugin specifications following the format given
 above.
-
-If `ensure_dependencies` is true, the plugins specified in `requires` will be installed.
 
 Plugins specified in `requires` are removed when no active plugins require them.
 

--- a/doc/packer.txt
+++ b/doc/packer.txt
@@ -267,10 +267,10 @@ setup({config})                                                *packer.setup()*
     If the user does not call this it will be called internally by
     |packer.add()|.
 
-add({spec})                                                     *packer.spec()*
-    `use` allows you to add one or more plugins to the managed set. It can be
+
+add({spec})                                                      *packer.add()*
+    `add` allows you to add one or more plugins to the managed set. It can be
     invoked as follows:
-    - With a single plugin location string, e.g. `use <STRING>`
     - With a single plugin specification table, e.g. >
       {
         'myusername/example',        -- The plugin location string

--- a/doc/packer.txt
+++ b/doc/packer.txt
@@ -1,4 +1,4 @@
-*packer.txt*                      A use-package inspired Neovim plugin manager
+
 *packer.nvim*
 
 Author: Wil Thomason <wil.thomason@gmail.com>
@@ -56,7 +56,7 @@ Then you can write your plugin specification in Lua, e.g. (in `~/.config/nvim/lu
   -- Only if your version of Neovim doesn't have https://github.com/neovim/neovim/pull/12632 merged
   vim._update_package_paths()
 
-  return require('packer').startup({
+  return require('packer').add{
     -- Packer can manage itself as an optional plugin
     {'wbthomason/packer.nvim'},
 
@@ -92,9 +92,9 @@ Then you can write your plugin specification in Lua, e.g. (in `~/.config/nvim/lu
 
     -- Plugins can have post-install/update hooks
     {'iamcco/markdown-preview.nvim', run = 'cd app && yarn install', cmd = 'MarkdownPreview'}
-  })
+  }
 
-`packer` provides the following commands after you've run and configured `packer` with `require('packer').startup(...)`: *packer-default-commands* *packer-commands*
+`packer` provides the following commands: *packer-default-commands* *packer-commands*
 
 `PackerClean`                                   *packer-commands-clean*
 Remove any disabled or unused plugins.
@@ -121,22 +121,23 @@ detailed in this section.
 
 STARTUP                                        *packer-startup*
 
-The easiest way to use `packer` is via the |packer.startup()| function. In
-short, `startup` is a convenience function for simple setup, and is invoked as
-`packer.startup(spec)`, where:
+The easiest way to use `packer` is via the |packer.add()| function.
+`spec` should be a table containing a list of plugin specs: >lua
 
-- `spec` can be a function: >
-  packer.startup(function() use 'tjdevries/colorbuddy.vim' end)
-- `spec` can be a table with a function as its first element and config
-  overrides as another element: >
-  packer.startup({
-    function() use 'tjdevries/colorbuddy.vim' end, config = { ... }
-    })
+  packer.add{
+    {'tjdevries/colorbuddy.vim', config = { ... }}
+  }
+
+<
+
+Configuration can be provided via |packer.setup()|: >lua
+
+  packer.setup{
+    -- YOUR CONFIG HERE --
+  }
 
 See |packer-configuration| for the allowed configuration keys.
 
-`startup` will handle calling |packer.init()| and |packer.reset()| for you, as
-well as creating the commands given in |packer-commands|.
 
 CONFIGURATION                                  *packer-configuration*
 `packer` provides the following configuration variables, presented in the
@@ -146,59 +147,50 @@ default values: >
     package_root   = util.join_paths(vim.fn.stdpath('data'), 'site', 'pack'),
     plugin_package = 'packer', -- The default package for plugins
     max_jobs = nil, -- Limit the number of simultaneous jobs. nil means no limit
-    preview_updates = false, -- If true, always preview updates before choosing which plugins to update, same as `PackerUpdate --preview`.
     git = {
-      cmd = 'git', -- The base command for git operations
-      depth = 1, -- Git clone depth
-      clone_timeout = 60, -- Timeout, in seconds, for git clones
+      cmd                = 'git', -- The base command for git operations
+      depth              = 1, -- Git clone depth
+      clone_timeout      = 60, -- Timeout, in seconds, for git clones
       default_url_format = 'https://github.com/%s' -- Lua format string used for "aaa/bbb" style plugins
     },
     log = { level = 'warn' }, -- The default print log level. One of: "trace", "debug", "info", "warn", "error", "fatal".
     display = {
       non_interactive = false, -- If true, disable display windows for all operations
-      compact = false, -- If true, fold updates results by default
-      open_fn  = nil, -- An optional function to open a window for packer's display
-      open_cmd = '65vnew \\[packer\\]', -- An optional command to open a window for packer's display
-      working_sym = '⟳', -- The symbol for a plugin being installed/updated
-      error_sym = '✗', -- The symbol for a plugin with an error in installation/updating
-      done_sym = '✓', -- The symbol for a plugin which has completed installation/updating
-      removed_sym = '-', -- The symbol for an unused plugin which was removed
-      moved_sym = '→', -- The symbol for a plugin which was moved (e.g. from opt to start)
-      header_sym = '━', -- The symbol for the header line in packer's display
-      show_all_info = true, -- Should packer show all update details automatically?
-      prompt_border = 'double', -- Border style of prompt popups.
+      working_sym     = '⟳', -- The symbol for a plugin being installed/updated
+      error_sym       = '✗', -- The symbol for a plugin with an error in installation/updating
+      done_sym        = '✓', -- The symbol for a plugin which has completed installation/updating
+      removed_sym     = '-', -- The symbol for an unused plugin which was removed
+      moved_sym       = '→', -- The symbol for a plugin which was moved (e.g. from opt to start)
+      header_sym      = '━', -- The symbol for the header line in packer's display
+      show_all_info   = true, -- Should packer show all update details automatically?
+      prompt_border   = 'double', -- Border style of prompt popups.
       keybindings = { -- Keybindings for the display window
-        quit = 'q',
+        quit          = 'q',
         toggle_update = 'u', -- only in preview
-        continue = 'c', -- only in preview
-        toggle_info = '<CR>',
-        diff = 'd',
+        continue      = 'c', -- only in preview
+        toggle_info   = '<CR>',
+        diff          = 'd',
         prompt_revert = 'r',
       }
     }
   }
 
+<
+
 SPECIFYING PLUGINS                             *packer-specifying-plugins*
 `packer` is based around declarative specification of plugins. You can declare
-a plugin using the function |packer.use()|, which I highly recommend locally
-binding to `use` for conciseness.
+a plugin using the function |packer.add()|.
 
-`use` takes either a string or a table. If a string is provided, it is treated
-as a plugin location for a non-optional plugin with no additional
-configuration. Plugin locations may be specified as:
+`add` takes a list of plugin specifications (strings or tables)
+
+Plugin locations may be specified as:
   1. Absolute paths to a local plugin
   2. Full URLs (treated as plugins managed with `git`)
   3. `username/repo` paths (treated as Github `git` plugins)
 
-A table given to `use` can take two forms:
-  1. A list of plugin specifications (strings or tables)
-  2. A table specifying a single plugin. It must have a plugin location string
-  as its first element, and may additionally have a number of optional keyword
-  elements, detailed in |packer.use()|
-
 CONFIGURING PLUGINS                            *packer-plugin-configuration*
 `packer` allows you to configure plugins either before they are loaded (the
-`setup` key described in |packer.use()|) or after they are loaded (the
+`config_pre` key described in |packer.add()|) or after they are loaded (the
 `config` key described in |packer.use()|).
 If functions are given for these keys, the functions will be passed the plugin
 name and information table as arguments.
@@ -269,8 +261,39 @@ Setting any of its keys to `false` will disable the corresponding keybinding.
 ==============================================================================
 API                                            *packer-api*
 
-startup()                                                      *packer.startup()*
-    `startup` is a convenience function for simple setup. See |packer-startup|
-    for details.
+setup({config})                                                *packer.setup()*
+    Setup and configure packer.
+
+    If the user does not call this it will be called internally by
+    |packer.add()|.
+
+add({spec})                                                     *packer.spec()*
+    `use` allows you to add one or more plugins to the managed set. It can be
+    invoked as follows:
+    - With a single plugin location string, e.g. `use <STRING>`
+    - With a single plugin specification table, e.g. >
+      {
+        'myusername/example',        -- The plugin location string
+        -- The following keys are all optional
+        opt = boolean,               -- Manually marks a plugin as optional.
+        branch = string,             -- Specifies a git branch to use
+        tag = string,                -- Specifies a git tag to use. Supports '*' for "latest tag"
+        commit = string,             -- Specifies a git commit to use
+        lock = boolean,              -- Skip updating this plugin in updates/syncs. Still cleans.
+        run = string, function, or table  -- Post-update/install hook. See |packer-plugin-hooks|
+        requires = string or list    -- Specifies plugin dependencies. See |packer-plugin-dependencies|
+        config = string or function, -- Specifies code to run after this plugin is loaded.
+        -- The following keys all imply lazy-loading
+        cmd = string or list,        -- Specifies commands which load this plugin.  Can be an autocmd pattern.
+        ft = string or list,         -- Specifies filetypes which load this plugin.
+        keys = string or list,       -- Specifies maps which load this plugin. See |packer-plugin-keybindings|
+        event = string or list,      -- Specifies autocommand events which load this plugin.
+        fn = string or list          -- Specifies functions which load this plugin.
+      }
+    - With a list of plugins specified in either of the above two forms
+
+    For the *cmd* option, the command may be a full command, or an autocommand pattern. If the command contains any
+    non-alphanumeric characters, it is assumed to be a pattern, and instead of creating a stub command, it creates
+    a CmdUndefined autocmd to load the plugin when a command that matches the pattern is invoked.
 
  vim:tw=78:ts=2:ft=help:norl:

--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -1,30 +1,14 @@
+local log = require('packer.log')
 local config = require('packer.config')
 
 local Config = config.Config
 
-local M = {}
+local did_setup = false
 
+local function setup(user_config)
+   log.debug('setup')
 
-
-
-
-
-
-
-
-
-function M.startup(spec)
-   local log = require('packer.log')
-   local plugin = require('packer.plugin')
-   local loader = require('packer.loader')
-
-   log.debug('STARTING')
-
-   assert(type(spec) == 'table')
-   assert(type(spec[1]) == 'table')
-
-   log.debug('PROCESSING CONFIG')
-   config(spec.config)
+   config(user_config)
 
    for _, dir in ipairs({ config.opt_dir, config.start_dir }) do
       if vim.fn.isdirectory(dir) == 0 then
@@ -32,12 +16,48 @@ function M.startup(spec)
       end
    end
 
+   did_setup = true
+end
+
+local M = {}
+
+function M.add(spec)
+   if not did_setup then
+      setup()
+   end
+
+   local plugin = require('packer.plugin')
+   local loader = require('packer.loader')
+
    log.debug('PROCESSING PLUGIN SPEC')
-   plugin.process_spec(spec[1])
+   plugin.process_spec(spec)
 
    log.debug('LOADING PLUGINS')
-
    loader.setup(plugin.plugins)
+end
+
+
+function M.setup(user_config, user_spec)
+   setup(user_config)
+
+   if user_spec then
+      M.add(user_spec)
+   end
+end
+
+
+
+
+
+function M.startup(spec)
+   log.debug('STARTING')
+   assert(type(spec) == 'table')
+
+   local user_spec = spec[1]
+   assert(type(user_spec) == "table")
+
+   M.setup(spec.config)
+   M.add(user_spec)
 end
 
 return M

--- a/teal/packer.tl
+++ b/teal/packer.tl
@@ -1,30 +1,14 @@
+local log    = require 'packer.log'
 local config = require 'packer.config'
 
 local Config = config.Config
 
-local M = {}
+local did_setup = false
 
-local record StartupSpec
-  {UserSpec}
+local function setup(user_config: Config)
+  log.debug('setup')
 
-  config: Config
-end
-
--- Convenience function for simple setup
--- spec can be a table with a table of plugin specifications as its first
--- element, config overrides as another element.
-function M.startup(spec: StartupSpec)
-  local log    = require 'packer.log'
-  local plugin = require 'packer.plugin'
-  local loader = require 'packer.loader'
-
-  log.debug('STARTING')
-
-  assert(type(spec) == 'table')
-  assert(type(spec[1]) == 'table')
-
-  log.debug('PROCESSING CONFIG')
-  config(spec.config)
+  config(user_config)
 
   for _, dir in ipairs{config.opt_dir, config.start_dir} do
     if vim.fn.isdirectory(dir) == 0 then
@@ -32,12 +16,48 @@ function M.startup(spec: StartupSpec)
     end
   end
 
+  did_setup = true
+end
+
+local M = {}
+
+function M.add(spec: UserSpec)
+  if not did_setup then
+    setup()
+  end
+
+  local plugin = require 'packer.plugin'
+  local loader = require 'packer.loader'
+
   log.debug('PROCESSING PLUGIN SPEC')
-  plugin.process_spec(spec[1])
+  plugin.process_spec(spec)
 
   log.debug('LOADING PLUGINS')
-
   loader.setup(plugin.plugins)
+end
+
+-- This should be safe to call multiple times.
+function M.setup(user_config: Config, user_spec: UserSpec)
+  setup(user_config)
+
+  if user_spec then
+    M.add(user_spec)
+  end
+end
+
+-- @deprecated use setup() instead
+-- Convenience function for simple setup
+-- spec can be a table with a table of plugin specifications as its first
+-- element, config overrides as another element.
+function M.startup(spec: table)
+  log.debug('STARTING')
+  assert(type(spec) == 'table')
+
+  local user_spec = spec[1] as UserSpec
+  assert(user_spec is UserSpec)
+
+  M.setup(spec.config as Config)
+  M.add(user_spec)
 end
 
 return M


### PR DESCRIPTION
- add `packer.add()` for adding plugins to the managed set
- add `packer.setup()` for overriding default config. Note this is optional and will be automatically called by packer.add()
- deprecate `packer.startup()`
- updated README and docs.
