### PR TITLE
feat: make all plugins opt by default

### DIFF
--- a/lua/packer/actions.lua
+++ b/lua/packer/actions.lua
@@ -100,7 +100,7 @@ local function update_helptags(results)
 end
 
 local function load_plugin(plugin)
-   if plugin.opt then
+   if not plugin.start then
       vim.cmd.packadd(plugin.name)
       return
    end
@@ -129,7 +129,7 @@ local function load_plugin(plugin)
 end
 
 local post_update_hook = a.sync(function(plugin, disp)
-   if plugin.run or not plugin.opt then
+   if plugin.run or plugin.start then
       a.main()
       load_plugin(plugin)
    end
@@ -214,7 +214,7 @@ end
 local function move_plugin(plugin, moves, fs_state)
    local from
    local to
-   if plugin.opt then
+   if not plugin.start then
       from = util.join_paths(config.start_dir, plugin.name)
       to = util.join_paths(config.opt_dir, plugin.name)
    else
@@ -311,7 +311,7 @@ local function fix_plugin_types(
 
    for _, v in ipairs(extra_plugins) do
       local plugin = plugins[v]
-      local wrong_install_dir = util.join_paths(plugin.opt and config.start_dir or config.opt_dir, plugin.name)
+      local wrong_install_dir = util.join_paths(plugin.start and config.opt_dir or config.start_dir, plugin.name)
       if vim.loop.fs_stat(wrong_install_dir) then
          move_plugin(plugin, moves, fs_state)
       end
@@ -346,6 +346,9 @@ local do_clean = a.sync(function(plugins, fs_state, removals)
 
    log.debug('Starting clean')
    local plugins_to_remove = vim.tbl_extend('force', fs_state.extra, fs_state.dirty)
+
+   log.debug('extra plugins', fs_state.extra)
+   log.debug('dirty plugins', fs_state.dirty)
 
    if not next(plugins_to_remove) then
       log.info('Already clean!')

--- a/lua/packer/display.lua
+++ b/lua/packer/display.lua
@@ -656,13 +656,13 @@ end
 
 local function load_state(plugin)
    if not plugin.loaded then
-      if not plugin.opt then
+      if plugin.start then
          return ' (not installed)'
       end
       return ' (not loaded)'
    end
 
-   if plugin.opt then
+   if plugin.lazy then
       return ' (manually loaded)'
    end
 

--- a/lua/packer/fsstate.lua
+++ b/lua/packer/fsstate.lua
@@ -57,6 +57,13 @@ local function get_installed_plugins()
    return opt_plugins, start_plugins
 end
 
+local function toboolean(x)
+   if x then
+      return true
+   end
+   return false
+end
+
 local function find_extra_plugins(
    plugins,
 
@@ -67,11 +74,11 @@ local function find_extra_plugins(
    local extra = {}
 
    for cond, p in pairs({
-         [false] = { plugins = opt_plugins, dir = config.opt_dir },
-         [true] = { plugins = start_plugins, dir = config.start_dir },
+         [true] = { plugins = opt_plugins, dir = config.opt_dir },
+         [false] = { plugins = start_plugins, dir = config.start_dir },
       }) do
       for _, name in pairs(p.plugins) do
-         if not plugins[name] or plugins[name].opt == cond then
+         if not plugins[name] or cond == toboolean(plugins[name].start) then
             extra[util.join_paths(p.dir, name)] = name
          end
       end
@@ -93,7 +100,7 @@ local find_dirty_plugins = a.sync(function(
 
    for plugin_name, plugin in pairs(plugins) do
       local plugin_installed = false
-      for _, name in pairs(plugin.opt and opt_plugins or start_plugins) do
+      for _, name in pairs(plugin.start and start_plugins or opt_plugins) do
          if name == plugin_name then
             plugin_installed = true
             break

--- a/teal/packer.tl
+++ b/teal/packer.tl
@@ -30,6 +30,9 @@ local function loader(plugins: {Plugin})
     if plugin.loaded then
       log.debug('Already loaded '..plugin.name)
     else
+      log.debug('Running loader for '..plugin.name)
+
+      -- Tidy up any lazy-loading state
       for _, d in pairs(plugin.destructors) do
         d()
       end
@@ -37,12 +40,25 @@ local function loader(plugins: {Plugin})
       -- Set the plugin as loaded before config is run in case something in the
       -- config tries to load this same plugin again
       plugin.loaded = true
-      apply_config(plugin, true)
-      if plugin.opt then
+
+      apply_config(plugin, true) -- spec.config_pre()
+
+      if not plugin.start then
+        if plugin.requires then
+          log.debug('Loading dependencies of '..plugin.name)
+          local all_plugins = require'packer.plugin'.plugins
+          local rplugins = vim.tbl_map(function(n: string): Plugin
+            return all_plugins[n]
+          end, plugin.requires)
+          loader(rplugins)
+        end
+
         -- never packadd a start plugin
+        log.debug('Loading '..plugin.name)
         vim.cmd.packadd(plugin.name)
       end
-      apply_config(plugin, false)
+
+      apply_config(plugin, false) -- spec.config()
     end
   end
 end
@@ -51,7 +67,7 @@ local function load_plugin_configs(plugins: {string:Plugin})
   local Handlers = require('packer.handlers')
 
   for _, plugin in pairs(plugins) do
-    if not plugin.opt then
+    if not plugin.lazy then
       loader({plugin})
     end
   end

--- a/teal/packer/actions.tl
+++ b/teal/packer/actions.tl
@@ -100,7 +100,7 @@ local function update_helptags(results: {string:Display.Result})
 end
 
 local function load_plugin(plugin: Plugin)
-  if plugin.opt then
+  if not plugin.start then
     vim.cmd.packadd(plugin.name)
     return
   end
@@ -129,7 +129,7 @@ local function load_plugin(plugin: Plugin)
 end
 
 local post_update_hook = a.sync(function(plugin: Plugin, disp: Display): {string}
-  if plugin.run or not plugin.opt then
+  if plugin.run or plugin.start then
     a.main()
     load_plugin(plugin)
   end
@@ -214,7 +214,7 @@ end
 local function move_plugin(plugin: Plugin, moves: {string:Display.Result}, fs_state: fsstate.FSState)
   local from: string
   local to: string
-  if plugin.opt then
+  if not plugin.start then
     from = util.join_paths(config.start_dir, plugin.name)
     to = util.join_paths(config.opt_dir, plugin.name)
   else
@@ -311,7 +311,7 @@ local function fix_plugin_types(
   -- NOTE: This function can only be run on plugins already installed
   for _, v in ipairs(extra_plugins) do
     local plugin = plugins[v]
-    local wrong_install_dir = util.join_paths(plugin.opt and config.start_dir or config.opt_dir, plugin.name)
+    local wrong_install_dir = util.join_paths(plugin.start and config.opt_dir or config.start_dir, plugin.name)
     if vim.loop.fs_stat(wrong_install_dir) then
       move_plugin(plugin, moves, fs_state)
     end
@@ -346,6 +346,9 @@ local do_clean = a.sync(function(plugins: {string:Plugin}, fs_state: fsstate.FSS
 
   log.debug 'Starting clean'
   local plugins_to_remove = vim.tbl_extend('force', fs_state.extra, fs_state.dirty)
+
+  log.debug('extra plugins', fs_state.extra)
+  log.debug('dirty plugins', fs_state.dirty)
 
   if not next(plugins_to_remove) then
     log.info 'Already clean!'

--- a/teal/packer/display.tl
+++ b/teal/packer/display.tl
@@ -656,13 +656,13 @@ end
 
 local function load_state(plugin: Plugin): string
   if not plugin.loaded then
-    if not plugin.opt then
+    if plugin.start then
       return ' (not installed)'
     end
     return ' (not loaded)'
   end
 
-  if plugin.opt then
+  if plugin.lazy then
     return ' (manually loaded)'
   end
 

--- a/teal/packer/fsstate.tl
+++ b/teal/packer/fsstate.tl
@@ -57,6 +57,13 @@ local function get_installed_plugins(): {string:string}, {string:string}
   return opt_plugins, start_plugins
 end
 
+local function toboolean(x: boolean): boolean
+  if x then
+    return true
+  end
+  return false
+end
+
 local function find_extra_plugins(
   plugins: {string:Plugin},
   -- Plugins installed in config.opt_dir
@@ -67,11 +74,11 @@ local function find_extra_plugins(
   local extra: {string:string} = {}
 
   for cond, p in pairs {
-    [false] = { plugins = opt_plugins  , dir = config.opt_dir  },
-    [true]  = { plugins = start_plugins, dir = config.start_dir},
+    [true]  = { plugins = opt_plugins  , dir = config.opt_dir  },
+    [false] = { plugins = start_plugins, dir = config.start_dir},
   } do
     for _, name in pairs(p.plugins) do
-      if not plugins[name] or plugins[name].opt == cond then
+      if not plugins[name] or cond == toboolean(plugins[name].start) then
         extra[util.join_paths(p.dir, name)] = name
       end
     end
@@ -93,7 +100,7 @@ local find_dirty_plugins = a.sync(function(
 
   for plugin_name, plugin in pairs(plugins) do
     local plugin_installed = false
-    for _, name in pairs(plugin.opt and opt_plugins or start_plugins) do
+    for _, name in pairs(plugin.start and start_plugins or opt_plugins) do
       if name == plugin_name then
         plugin_installed = true
         break

--- a/teal/packer/plugin.tl
+++ b/teal/packer/plugin.tl
@@ -12,7 +12,8 @@ local record M
     rev        : string
     tag        : string
     commit     : string
-    opt        : boolean
+    lazy       : boolean
+    start      : boolean
     keys       : string|{string|{string,string}}
     event      : string|{string}
     ft         : string|{string}
@@ -56,8 +57,17 @@ local record M
     url              : string
     lock             : boolean
     breaking_commits : {string}
-    opt              : boolean
-    loaded           : boolean
+
+    -- Lazy loaded
+    lazy: boolean
+
+    -- Install as a 'start' plugin
+    start: boolean
+
+    loaded: boolean
+
+    -- Built from a simple plugin spec (a string)
+    simple: boolean
 
     -- Callbacks to destroy unused lazy-load handlers when a plugin is loaded
     destructors      : {integer:function()}
@@ -68,6 +78,8 @@ local record M
 
   plugins: {string:Plugin}
 end
+
+local destructor_mt = { __mode = 'kv' }
 
 M.plugins = {}
 
@@ -168,6 +180,7 @@ function M.process_spec(
 
   if id == nil then
     log.warn('No plugin name provided!')
+    log.debug('No plugin name provided for spec', spec)
     return {}
   end
 
@@ -178,15 +191,21 @@ function M.process_spec(
     return {}
   end
 
-  if M.plugins[name] then
-    if required_by then
-      M.plugins[name].required_by = M.plugins[name].required_by or {}
-      table.insert(M.plugins[name].required_by, required_by.name)
+  local existing = M.plugins[name]
+  local simple = spec0 is string
+
+  if existing then
+    if simple then
+      log.debug('Ignoring simple plugin spec'..name)
+      return {[name] = existing}
     else
-      log.warn(fmt('Plugin "%s" is specified more than once!', name))
+      if not existing.simple then
+        log.warn(fmt('Plugin "%s" is specified more than once!', name))
+        return {[name] = existing}
+      end
     end
 
-    return {[name] = M.plugins[name]}
+    log.debug('Overriding simple plugin spec: '..name)
   end
 
   local url, ptype = guess_plugin_type(path)
@@ -198,7 +217,9 @@ function M.process_spec(
     rev         = spec.rev,
     tag         = spec.tag,
     commit      = spec.commit,
-    opt         = spec.opt,
+    lazy        = spec.lazy,
+    start       = spec.start,
+    simple      = simple,
     keys        = normkeys(spec.keys),
     event       = normcond(spec.event),
     ft          = normcond(spec.ft   ),
@@ -210,42 +231,44 @@ function M.process_spec(
     type        = ptype,
     config_pre  = spec.config_pre,
     config      = spec.config,
-    required_by = required_by and {required_by.name} or nil,
     revs        = {},
 
     -- Because a destructor can be shared across plugins, store the callbacks
     -- as weak references. When they are removed from the handlers internal
     -- table, they will be garbage collected.
-    destructors = setmetatable({}, { __mode = 'kv' })
+    destructors = setmetatable({}, destructor_mt)
   }
+
+  if required_by then
+    plugin.required_by = plugin.required_by or {}
+    table.insert(plugin.required_by, required_by.name)
+  end
+
+  if existing and existing.required_by then
+    plugin.required_by = plugin.required_by or {}
+    vim.list_extend(plugin.required_by, existing.required_by)
+  end
 
   M.plugins[name] = plugin
 
-  if not plugin.opt then
-    plugin.opt = plugin.keys ~= nil
+  if not plugin.lazy then
+    plugin.lazy = plugin.keys ~= nil
       or plugin.ft ~= nil
       or plugin.cmd ~= nil
       or plugin.event ~= nil
       or plugin.enable ~= nil
-      or (required_by or {}).opt
+      or (required_by or {}).lazy
   end
 
-  plugin.install_path = util.join_paths(plugin.opt and config.opt_dir or config.start_dir, name)
+  plugin.install_path = util.join_paths(plugin.start and config.start_dir or config.opt_dir, name)
 
   if spec.requires then
-    if required_by then
-      -- TODO(lewis6991): Allow nesting, but only allow a plugin to be specified
-      -- via a non-string spec once.
-      log.warn(fmt('(%s) Nested requires are not support', name))
-    else
-      local sr = spec.requires
-      local r: {string|M.UserSpec} = sr is string and {sr} or  sr
+    local sr = spec.requires
+    local r: {string|M.UserSpec} = sr is string and {sr} or  sr
 
-      -- TODO(lewis6991): handle cyclic deps
-      plugin.requires = {}
-      for _, s in ipairs(r) do
-        vim.list_extend(plugin.requires, vim.tbl_keys(M.process_spec(s, plugin)))
-      end
+    plugin.requires = {}
+    for _, s in ipairs(r) do
+      vim.list_extend(plugin.requires, vim.tbl_keys(M.process_spec(s, plugin)))
     end
   end
 

--- a/types/vim.d.tl
+++ b/types/vim.d.tl
@@ -36,6 +36,8 @@ local record M
   -- Assume result_type == 'indices'
   diff: function(string|{string}, string|{string}, table): {DiffResult}
 
+  env: {string:string}
+
   record json
     encode: function(any): string
     decode: function(string): any


### PR DESCRIPTION
- Renamed `spec.opt` to `spec.lazy`
- Added `spec.start`
- Make sure to load plugin dependencies before loading the plugin
- Allow nested dependency specs
- Only allow a plugin to be specified as a table once. This is tracked
  with `plugin.simple`.
