### PR TITLE
feat(compile): use nvim_create_user_command to make lazy-load commands

### DIFF
--- a/lua/packer/compile.lua
+++ b/lua/packer/compile.lua
@@ -571,7 +571,9 @@ local function make_loaders(_, plugins, output_lua, should_profile)
     local command_line
     if string.match(command, '^%w+$') then
       command_line = fmt(
-        'pcall(vim.cmd, [[command -nargs=* -range -bang -complete=file %s lua require("packer.load")({%s}, { cmd = "%s", l1 = <line1>, l2 = <line2>, bang = <q-bang>, args = <q-args>, mods = "<mods>" }, _G.packer_plugins)]])',
+        [[pcall(vim.api.nvim_create_user_command, '%s', function(cmdargs)
+          require('packer.load')({%s}, { cmd = '%s', l1 = cmdargs.line1, l2 = cmdargs.line2, bang = cmdargs.bang, args = cmdargs.args, mods = cmdargs.mods }, _G.packer_plugins)
+        end, packer_cmd_opts)]],
         command,
         table.concat(names, ', '),
         command
@@ -749,6 +751,7 @@ local function make_loaders(_, plugins, output_lua, should_profile)
   -- The command and keymap definitions
   if next(command_defs) then
     table.insert(result, '\n-- Command lazy-loads')
+    table.insert(result, "local packer_cmd_opts = {nargs='*', range=true, bang=true, complete='file'}")
     timed_chunk(command_defs, 'Defining lazy-load commands', result)
     table.insert(result, '')
   end

--- a/lua/packer/compile.lua
+++ b/lua/packer/compile.lua
@@ -570,10 +570,17 @@ local function make_loaders(_, plugins, output_lua, should_profile)
   for command, names in pairs(commands) do
     local command_line
     if string.match(command, '^%w+$') then
+      -- Better command completions here are due to @folke
       command_line = fmt(
         [[pcall(vim.api.nvim_create_user_command, '%s', function(cmdargs)
           require('packer.load')({%s}, { cmd = '%s', l1 = cmdargs.line1, l2 = cmdargs.line2, bang = cmdargs.bang, args = cmdargs.args, mods = cmdargs.mods }, _G.packer_plugins)
-        end, packer_cmd_opts)]],
+        end,
+        {nargs = '*', range = true, bang = true, complete = function()
+          require('packer.load')({%s}, { cmd = '%s' }, _G.packer_plugins)
+          vim.api.nvim_input('<space><bs><tab>')
+      end})]],
+        command,
+        table.concat(names, ', '),
         command,
         table.concat(names, ', '),
         command
@@ -751,7 +758,6 @@ local function make_loaders(_, plugins, output_lua, should_profile)
   -- The command and keymap definitions
   if next(command_defs) then
     table.insert(result, '\n-- Command lazy-loads')
-    table.insert(result, "local packer_cmd_opts = {nargs='*', range=true, bang=true, complete='file'}")
     timed_chunk(command_defs, 'Defining lazy-load commands', result)
     table.insert(result, '')
   end

--- a/lua/packer/load.lua
+++ b/lua/packer/load.lua
@@ -80,7 +80,7 @@ end
 local function apply_cause_side_effcts(cause)
   if cause.cmd then
     local lines = cause.l1 == cause.l2 and '' or (cause.l1 .. ',' .. cause.l2)
-    cmd(fmt('%s %s%s%s %s', cause.mods or '', lines, cause.cmd, cause.bang, cause.args))
+    cmd(fmt('%s %s%s%s %s', cause.mods or '', lines, cause.cmd, cause.bang and '!' or '', cause.args))
   elseif cause.keys then
     local extra = ''
     while true do


### PR DESCRIPTION
This is a slight performance improvement over the old style of command creation, and moves `packer` toward the modern Neovim APIs

Not immediately merging because I need to track down the Neovim version when `nvim_create_user_command` was released - if it's v0.8.0, I'll want to hold off on this change since the release was quite recent.

I could add logic to test for the function's existence and fall back to the old method if it's not present, and might. But for now, I'd prefer to avoid adding that complexity.
