### PR TITLE
feat!: re-implement cli with subcommands

### DIFF
--- a/lua/packer/cli.lua
+++ b/lua/packer/cli.lua
@@ -1,0 +1,51 @@
+
+local M = {}
+
+
+
+local function plugin_complete(lead, _)
+   local plugins = require('packer.plugin').plugins
+   local completion_list = vim.tbl_filter(function(name)
+      return vim.startswith(name, lead)
+   end, vim.tbl_keys(plugins))
+   table.sort(completion_list)
+   return completion_list
+end
+
+function M.complete(arglead, line)
+   local words = vim.split(line, '%s+')
+   local n = #words
+
+   local actions = require('packer.actions')
+   local matches = {}
+   if n == 2 then
+      matches = vim.tbl_keys(actions)
+
+
+
+
+
+
+
+   elseif n > 2 then
+      matches = plugin_complete(arglead)
+
+   end
+   return matches
+end
+
+function M.run(params)
+   local func = params.fargs[1]
+
+   local actions = require('packer.actions')
+
+   local cmd_func = actions[func]
+   if cmd_func then
+      cmd_func()
+      return
+   end
+
+   error(string.format('%s is not a valid function or action', func))
+end
+
+return M

--- a/plugin/packer.lua
+++ b/plugin/packer.lua
@@ -1,24 +1,15 @@
--- Completion user plugins
--- Intended to provide completion for PackerUpdate/Sync/Install command
-local function plugin_complete(lead, _)
-  local plugins = require 'packer.plugin'.plugins
-  local completion_list = vim.tbl_filter(function(name)
-    return vim.startswith(name, lead)
-  end, vim.tbl_keys(plugins))
-  table.sort(completion_list)
-  return completion_list
-end
 
-for k, v in pairs {
-  install = { 'PackerInstall', plugin_complete},
-  update  = { 'PackerUpdate' , plugin_complete},
-  sync    = { 'PackerSync'                    },
-  clean   = { 'PackerClean'                   },
-  status  = { 'PackerStatus'                  },
-} do
-  vim.api.nvim_create_user_command(v[1], function(args)
-    return require('packer.actions')[k](unpack(args.fargs))
-  end, { nargs = '*', complete = v[2] })
-end
+vim.api.nvim_create_user_command(
+  'Packer',
+  function(args)
+    return require('packer.cli').run(args)
+  end, {
+    nargs = '*',
+    complete = function(arglead, line)
+      return require('packer.cli').complete(arglead, line)
+    end
+  }
+)
 
+-- Run 'config' keys in user spec.
 require'packer.plugin_config'.run()

--- a/teal/packer/cli.tl
+++ b/teal/packer/cli.tl
@@ -1,0 +1,47 @@
+
+local M = {}
+
+local function command_complete(): {string}
+  local actions = require('packer.actions') as {string:function}
+  return vim.tbl_keys(actions)
+end
+
+-- Completion user plugins
+-- Intended to provide completion for PackerUpdate/Sync/Install command
+local function plugin_complete(lead: string, _: string): {string}
+  local plugins = require 'packer.plugin'.plugins
+  local completion_list = vim.tbl_filter(function(name: string): boolean
+    return vim.startswith(name, lead)
+  end, vim.tbl_keys(plugins))
+  table.sort(completion_list)
+  return completion_list
+end
+
+function M.complete(arglead: string, line: string): {string}
+  local words = vim.split(line, '%s+')
+  local n: integer = #words
+
+  local matches: {string} = {}
+  if n == 2 then
+    matches = command_complete()
+  elseif n > 2 then
+    matches = plugin_complete(arglead)
+  end
+  return matches
+end
+
+function M.run(params: vim.api.UserCmdParams)
+  local func = params.fargs[1]
+
+  local actions = require('packer.actions') as {string:function}
+
+  local cmd_func = actions[func]
+  if cmd_func then
+    cmd_func()
+    return
+  end
+
+  error(string.format('%s is not a valid function or action', func))
+end
+
+return M


### PR DESCRIPTION
- Removed commands:
  - `PackerInstall`
  - `PackerUpdate`
  - `PackerSync`
  - `PackerClean`
  - `PackerStatus`

- Added command `Packer` with subcommands:
  - `install`
  - `update`
  - `sync`
  - `clean`
  - `status`
  - any other exported functions from the `packer.actions` module.
