### PR TITLE
Fix bug where hererocks installation hangs

### DIFF
--- a/lua/packer/jobs.lua
+++ b/lua/packer/jobs.lua
@@ -50,7 +50,7 @@ end
 local spawn = a.wrap(function(cmd, options, callback)
   local handle = nil
   local timer = nil
-  handle = loop.spawn(cmd, options, function(exit_code, signal)
+  handle, pid = loop.spawn(cmd, options, function(exit_code, signal)
     handle:close()
     if timer ~= nil then
       timer:stop()
@@ -76,6 +76,13 @@ local spawn = a.wrap(function(cmd, options, callback)
         loop.read_start(pipe, options.stdio_callbacks[i])
       end
     end
+  end
+
+  if handle == nil then 
+      -- pid is an error string in this case 
+      log.error(string.format("Failed spawning command: %s because %s", cmd, pid))
+      callback(-1, pid)
+      return 
   end
 
   if options.timeout then


### PR DESCRIPTION
Not all systems have a `python` executable in their path. In this situation, sync will never complete with the message: "installing hererocks...". This fix will log the situation and callback with an error code.

Issue #886 