### PR TITLE
fix(compile): do not call real commands in lazyloading dummy commands…

### DIFF
--- a/lua/packer/compile.lua
+++ b/lua/packer/compile.lua
@@ -576,7 +576,7 @@ local function make_loaders(_, plugins, output_lua, should_profile)
           require('packer.load')({%s}, { cmd = '%s', l1 = cmdargs.line1, l2 = cmdargs.line2, bang = cmdargs.bang, args = cmdargs.args, mods = cmdargs.mods }, _G.packer_plugins)
         end,
         {nargs = '*', range = true, bang = true, complete = function()
-          require('packer.load')({%s}, { cmd = '%s' }, _G.packer_plugins)
+          require('packer.load')({%s}, {}, _G.packer_plugins)
           return vim.fn.getcompletion('%s ', 'cmdline')
       end})]],
         command,


### PR DESCRIPTION
… (#1179, #1166)

Current version of packer will make unexpected call to lazy-loaded commands when packer tries to get completion of that command.

This commit fixes the issue by passing empty table as `cause` to function `packer_load` to avoid calling the actual command in this case.