### PR TITLE
Multiple modifications to improve snapshot functionality and user autocmds

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,7 @@ default configuration values (and structure of the configuration table) are:
 ```lua
 {
   ensure_dependencies   = true, -- Should packer install plugin dependencies?
+  auto_snapshot = false,  -- Automatically updates snapshot file when package changes
   snapshot = nil, -- Name of the snapshot you would like to load at startup
   snapshot_path = join_paths(stdpath 'cache', 'packer.nvim'), -- Default save directory for snapshots
   package_root   = util.join_paths(vim.fn.stdpath('data'), 'site', 'pack'),

--- a/README.md
+++ b/README.md
@@ -566,7 +566,14 @@ name and information table as arguments.
 require knowing when the operations are complete, you can use the following `User` autocmds (see
 `:help User` for more info on how to use):
 
-- `PackerComplete`: Fires after install, update, clean, and sync asynchronous operations finish.
+- `PackerInstallComplete`: Fires after install
+- `PackerUpdateComplete`: Fires after update
+- `PackerCleanComplete`: Fires after clean
+- `PackerSyncComplete`: Fires after sync
+- `PackerSnapshotComplete`: Fires after snapshot
+- `PackerSnapshotRollbackComplete`: Fires after snapshot rollback
+- `PackerSnapshotDeleteComplete`: Fires after snapshot deletion
+- `PackerCompileComplete`: Fires after compilation (before `PackerCompileDone`)
 - `PackerCompileDone`: Fires after compiling (see [the section on compilation](#compiling-lazy-loaders))
 
 ### Using a floating window

--- a/README.md
+++ b/README.md
@@ -286,8 +286,8 @@ default configuration values (and structure of the configuration table) are:
   ensure_dependencies   = true, -- Should packer install plugin dependencies?
   snapshot = {
     auto = false, -- Automatically updates snapshot file when package changes
-    name = nil, -- Name of the snapshot you would like to load at startup
-    path = join_paths(stdpath 'cache', 'packer.nvim'), -- Default save directory for snapshots
+    name = function() return os.date('%Y-%m-%d') .. '.json' end, -- Name of the snapshot you would like to load at startup, can be string or function returns a string
+    path = join_paths(stdpath 'cache', 'packer.nvim'), -- Default save directory for snapshots, can be string or function returns a string
     silent_overwrite = false, -- overwrite existing snapshot without confirm
   },
   package_root   = util.join_paths(vim.fn.stdpath('data'), 'site', 'pack'),

--- a/README.md
+++ b/README.md
@@ -284,9 +284,11 @@ default configuration values (and structure of the configuration table) are:
 ```lua
 {
   ensure_dependencies   = true, -- Should packer install plugin dependencies?
-  auto_snapshot = false,  -- Automatically updates snapshot file when package changes
-  snapshot = nil, -- Name of the snapshot you would like to load at startup
-  snapshot_path = join_paths(stdpath 'cache', 'packer.nvim'), -- Default save directory for snapshots
+  snapshot = {
+    auto = false, -- Automatically updates snapshot file when package changes
+    name = nil, -- Name of the snapshot you would like to load at startup
+    path = join_paths(stdpath 'cache', 'packer.nvim'), -- Default save directory for snapshots
+  },
   package_root   = util.join_paths(vim.fn.stdpath('data'), 'site', 'pack'),
   compile_path = util.join_paths(vim.fn.stdpath('config'), 'plugin', 'packer_compiled.lua'),
   plugin_package = 'packer', -- The default package for plugins

--- a/README.md
+++ b/README.md
@@ -288,6 +288,7 @@ default configuration values (and structure of the configuration table) are:
     auto = false, -- Automatically updates snapshot file when package changes
     name = nil, -- Name of the snapshot you would like to load at startup
     path = join_paths(stdpath 'cache', 'packer.nvim'), -- Default save directory for snapshots
+    silent_overwrite = false, -- overwrite existing snapshot without confirm
   },
   package_root   = util.join_paths(vim.fn.stdpath('data'), 'site', 'pack'),
   compile_path = util.join_paths(vim.fn.stdpath('config'), 'plugin', 'packer_compiled.lua'),

--- a/doc/packer.txt
+++ b/doc/packer.txt
@@ -202,8 +202,8 @@ default values: >lua
     ensure_dependencies   = true, -- Should packer install plugin dependencies?
     snapshot = {
       auto = false, -- Automatically updates snapshot file when package changes
-      name = nil, -- Name of the snapshot you would like to load at startup
-      path = join_paths(stdpath 'cache', 'packer.nvim'), -- Default save directory for snapshots
+      name = function() return os.date('%Y-%m-%d') .. '.json' end, -- Name of the snapshot you would like to load at startup, can be string or function returns a string
+      path = join_paths(stdpath 'cache', 'packer.nvim'), -- Default save directory for snapshots, can be string or function returns a string
       silent_overwrite = false, -- overwrite existing snapshot without confirm
     },
     package_root   = util.join_paths(vim.fn.stdpath('data'), 'site', 'pack'),

--- a/doc/packer.txt
+++ b/doc/packer.txt
@@ -200,6 +200,9 @@ structure of the `config` table expected by `startup` or `init`, with their
 default values: >lua
   {
     ensure_dependencies   = true, -- Should packer install plugin dependencies?
+    auto_snapshot = false,  -- Automatically updates snapshot file when package changes
+    snapshot = nil, -- Name of the snapshot you would like to load at startup
+    snapshot_path = join_paths(stdpath 'cache', 'packer.nvim'), -- Default save directory for snapshots
     package_root   = util.join_paths(vim.fn.stdpath('data'), 'site', 'pack'),
     compile_path = util.join_paths(vim.fn.stdpath('config'), 'plugin', 'packer_compiled.lua'),
     plugin_package = 'packer', -- The default package for plugins

--- a/doc/packer.txt
+++ b/doc/packer.txt
@@ -204,6 +204,7 @@ default values: >lua
       auto = false, -- Automatically updates snapshot file when package changes
       name = nil, -- Name of the snapshot you would like to load at startup
       path = join_paths(stdpath 'cache', 'packer.nvim'), -- Default save directory for snapshots
+      silent_overwrite = false, -- overwrite existing snapshot without confirm
     },
     package_root   = util.join_paths(vim.fn.stdpath('data'), 'site', 'pack'),
     compile_path = util.join_paths(vim.fn.stdpath('config'), 'plugin', 'packer_compiled.lua'),

--- a/doc/packer.txt
+++ b/doc/packer.txt
@@ -200,9 +200,11 @@ structure of the `config` table expected by `startup` or `init`, with their
 default values: >lua
   {
     ensure_dependencies   = true, -- Should packer install plugin dependencies?
-    auto_snapshot = false,  -- Automatically updates snapshot file when package changes
-    snapshot = nil, -- Name of the snapshot you would like to load at startup
-    snapshot_path = join_paths(stdpath 'cache', 'packer.nvim'), -- Default save directory for snapshots
+    snapshot = {
+      auto = false, -- Automatically updates snapshot file when package changes
+      name = nil, -- Name of the snapshot you would like to load at startup
+      path = join_paths(stdpath 'cache', 'packer.nvim'), -- Default save directory for snapshots
+    },
     package_root   = util.join_paths(vim.fn.stdpath('data'), 'site', 'pack'),
     compile_path = util.join_paths(vim.fn.stdpath('config'), 'plugin', 'packer_compiled.lua'),
     plugin_package = 'packer', -- The default package for plugins

--- a/doc/packer.txt
+++ b/doc/packer.txt
@@ -502,9 +502,24 @@ implement automations that require knowing when the operations are complete,
 you can use the following User autocmds (see |User| for more info on how to
 use):
 
-`PackerComplete`       Fires after install, update, clean, and sync
-                     asynchronous operations finish.
-`PackerCompileDone`    Fires after compiling (see |packer-lazy-load|)
+`PackerInstallComplete`             Fires after install
+
+`PackerUpdateComplete`              Fires after update
+
+`PackerCleanComplete`               Fires after clean
+
+`PackerSyncComplete`                Fires after sync
+
+`PackerSnapshotComplete`            Fires after snapshot
+
+`PackerSnapshotRollbackComplete`    Fires after snapshot rollback
+
+`PackerSnapshotDeleteComplete`      Fires after snapshot deletion
+
+`PackerCompileComplete`             Fires after compilation,
+                                  before `PackerCompileDone`
+
+`PackerCompileDone`                 Fires after compiling (see |packer-lazy-load|)
 
 ==============================================================================
 API                                            *packer-api*

--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -370,29 +370,12 @@ end
 
 packer.__manage_all = manage_all_plugins
 
-local function has_actual_updates(results)
-  if not results then return false end
-  local plugin_utils = require('packer.plugin_utils')
-  for plugin_name, result in pairs(results.updates) do
-    local plugin = results.plugins[plugin_name]
-    if result.ok and plugin.type == plugin_utils.git_plugin_type
-          and plugin.revs[1] ~= plugin.revs[2] then
-        return true
-      end
-  end
-  return false
-end
-
 --- Hook to fire events after packer operations
 packer.on_complete = vim.schedule_wrap(function(event_name, results)
   vim.cmd(string.format('doautocmd User Packer%sComplete', event_name))
   vim.notify(string.format('Packer%s complete', event_name),
     'info', { title = 'Packer' })
-  if config.snapshot.auto and results
-    and ((has_actual_updates(results))
-          or (vim.fn.empty(results.removals) == 0)
-          or (vim.fn.empty(results.installs) == 0))
-  then
+  if vim.tbl_contains({ 'Sync', 'Update', 'Clean', 'Install' }, event_name) then
     packer.snapshot(config.snapshot.name)
   end
 end)

--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -147,7 +147,7 @@ packer.init = function(user_config)
 end
 
 packer.make_commands = function()
-  vim.cmd [[command! -nargs=+ -complete=customlist,v:lua.require'packer.snapshot'.completion.create PackerSnapshot  lua require('packer').snapshot(<f-args>)]]
+  vim.cmd [[command! -nargs=* -complete=customlist,v:lua.require'packer.snapshot'.completion.create PackerSnapshot  lua require('packer').snapshot(<f-args>)]]
   vim.cmd [[command! -nargs=+ -complete=customlist,v:lua.require'packer.snapshot'.completion.rollback PackerSnapshotRollback  lua require('packer').rollback(<f-args>)]]
   vim.cmd [[command! -nargs=+ -complete=customlist,v:lua.require'packer.snapshot'.completion.snapshot PackerSnapshotDelete lua require('packer.snapshot').delete(<f-args>)]]
   vim.cmd [[command! -nargs=* -complete=customlist,v:lua.require'packer'.plugin_complete PackerInstall lua require('packer').install(<f-args>)]]
@@ -879,7 +879,8 @@ packer.snapshot = function(snapshot_name, ...)
   local snapshot = require 'packer.snapshot'
   local log = require_and_configure 'log'
   local args = { ... }
-  snapshot_name = snapshot_name or require('os').date '%Y-%m-%d'
+  snapshot_name = (not vim.fn.empty(snapshot_name) and snapshot_name)
+    or config.snapshot or require('os').date '%Y-%m-%d'
   local snapshot_path = vim.fn.expand(snapshot_name)
 
   local fmt = string.format

--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -10,6 +10,7 @@ local packer = {}
 local config_defaults = {
   ensure_dependencies = true,
   snapshot = nil,
+  auto_snapshot = false,
   snapshot_path = join_paths(stdpath 'cache', 'packer.nvim'),
   package_root = join_paths(stdpath 'data', 'site', 'pack'),
   compile_path = join_paths(stdpath 'config', 'plugin', 'packer_compiled.lua'),

--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -943,7 +943,7 @@ end
 ---@vararg string @ if provided, the only plugins to be rolled back,
 ---otherwise all the plugins will be rolled back
 packer.rollback = function(snapshot_name, ...)
-  vim.notify('Start rolling back...')
+  vim.notify('Start rolling back, please wait...')
   local args = { ... }
   local a = require 'packer.async'
   local async = a.sync

--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -147,7 +147,6 @@ packer.init = function(user_config)
   end
 
   config = util.deep_extend('force', config, user_config)
-  print(config.snapshot.path)
   packer.reset()
   config.package_root = vim.fn.fnamemodify(config.package_root, ':p')
   local _

--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -933,13 +933,17 @@ packer.snapshot = function(snapshot_name, ...)
   local write_snapshot = true
 
   if vim.fn.filereadable(snapshot_path) == 1 then
-    vim.ui.select(
-      { 'Replace', 'Cancel' },
-      { prompt = fmt("Do you want to replace '%s'?", snapshot_path) },
-      function(_, idx)
-        write_snapshot = idx == 1
-      end
-    )
+    if config.snapshot.silent_overwrite then
+      write_snapshot = true
+    else
+      vim.ui.select(
+        { 'Replace', 'Cancel' },
+        { prompt = fmt("Do you want to replace '%s'?", snapshot_path) },
+        function(_, idx)
+          write_snapshot = idx == 1
+        end
+      )
+    end
   end
 
   async(function()

--- a/lua/packer/compile.lua
+++ b/lua/packer/compile.lua
@@ -576,7 +576,7 @@ local function make_loaders(_, plugins, output_lua, should_profile)
           require('packer.load')({%s}, { cmd = '%s', l1 = cmdargs.line1, l2 = cmdargs.line2, bang = cmdargs.bang, args = cmdargs.args, mods = cmdargs.mods }, _G.packer_plugins)
         end,
         {nargs = '*', range = true, bang = true, complete = function()
-          require('packer.load')({%s}, { cmd = '%s' }, _G.packer_plugins)
+          require('packer.load')({%s}, {}, _G.packer_plugins)
           return vim.fn.getcompletion('%s ', 'cmdline')
       end})]],
         command,

--- a/lua/packer/snapshot.lua
+++ b/lua/packer/snapshot.lua
@@ -18,15 +18,15 @@ snapshot.cfg = function(_config)
   config = _config
 end
 
---- Completion for listing snapshots in `config.snapshot_path`
+--- Completion for listing snapshots in `config.snapshot.path`
 --- Intended to provide completion for PackerSnapshotDelete command
 snapshot.completion.snapshot = function(lead, cmdline, pos)
   local completion_list = {}
-  if config.snapshot_path == nil then
+  if config.snapshot.path == nil then
     return completion_list
   end
 
-  local dir = vim.loop.fs_opendir(config.snapshot_path)
+  local dir = vim.loop.fs_opendir(config.snapshot.path)
 
   if dir ~= nil then
     local res = vim.loop.fs_readdir(dir)
@@ -57,7 +57,7 @@ snapshot.completion.create = function(lead, cmdline, pos)
   return {}
 end
 
---- Completion for listing snapshots in `config.snapshot_path` and single plugins after
+--- Completion for listing snapshots in `config.snapshot.path` and single plugins after
 --- the first argument is provided
 --- Intended to provide completion for PackerSnapshotRollback command
 snapshot.completion.rollback = function(lead, cmdline, pos)
@@ -209,7 +209,7 @@ snapshot.delete = function(snapshot_name)
   assert(type(snapshot_name) == 'string', fmt('Expected string, got %s', type(snapshot_name)))
   ---@type string
   local snapshot_path = vim.loop.fs_realpath(snapshot_name)
-    or vim.loop.fs_realpath(util.join_paths(config.snapshot_path, snapshot_name))
+    or vim.loop.fs_realpath(util.join_paths(config.snapshot.path, snapshot_name))
 
   if snapshot_path == nil then
     local warn = fmt("Snapshot '%s' is wrong or doesn't exist", snapshot_name)

--- a/lua/packer/snapshot.lua
+++ b/lua/packer/snapshot.lua
@@ -225,6 +225,7 @@ snapshot.delete = function(snapshot_name)
     local warn = "Couldn't delete " .. snapshot_path
     log.warn(warn)
   end
+  require('packer').on_complete('SnapshotDelete')
 end
 
 return snapshot

--- a/tests/snapshot_spec.lua
+++ b/tests/snapshot_spec.lua
@@ -111,7 +111,7 @@ end
 local snapshotted_plugins = {}
 a.describe('Packer testing ', function()
   local snapshot_name = 'test'
-  local test_path = join_paths(config.snapshot.path, snapshot_name)
+  local test_path = join_paths(config.snapshot_path, snapshot_name)
   local snapshot = require 'packer.snapshot'
   snapshot.cfg(config)
 
@@ -154,7 +154,7 @@ a.describe('Packer testing ', function()
 
   a.describe('packer.rollback()', function()
     local rollback_snapshot_name = 'rollback_test'
-    local rollback_test_path = join_paths(config.snapshot.path, rollback_snapshot_name)
+    local rollback_test_path = join_paths(config.snapshot_path, rollback_snapshot_name)
     local prev_commit_cmd = 'git rev-parse --short HEAD~5'
     local get_rev_cmd = 'git rev-parse --short HEAD'
 

--- a/tests/snapshot_spec.lua
+++ b/tests/snapshot_spec.lua
@@ -111,7 +111,7 @@ end
 local snapshotted_plugins = {}
 a.describe('Packer testing ', function()
   local snapshot_name = 'test'
-  local test_path = join_paths(config.snapshot_path, snapshot_name)
+  local test_path = join_paths(config.snapshot.path, snapshot_name)
   local snapshot = require 'packer.snapshot'
   snapshot.cfg(config)
 
@@ -154,7 +154,7 @@ a.describe('Packer testing ', function()
 
   a.describe('packer.rollback()', function()
     local rollback_snapshot_name = 'rollback_test'
-    local rollback_test_path = join_paths(config.snapshot_path, rollback_snapshot_name)
+    local rollback_test_path = join_paths(config.snapshot.path, rollback_snapshot_name)
     local prev_commit_cmd = 'git rev-parse --short HEAD~5'
     local get_rev_cmd = 'git rev-parse --short HEAD'
 

--- a/tests/snapshot_spec.lua
+++ b/tests/snapshot_spec.lua
@@ -16,8 +16,12 @@ local fmt = string.format
 
 local config = {
   ensure_dependencies = true,
-  snapshot = nil,
-  snapshot_path = join_paths(stdpath 'cache', 'packer.nvim'),
+  snapshot = {
+    auto = false,
+    name = function() return os.date('%Y-%m-%d') .. '.json' end,
+    path = join_paths(stdpath 'cache', 'packer.nvim'),
+    silent_overwrite = false,
+  },
   package_root = join_paths(stdpath 'data', 'site', 'pack'),
   compile_path = join_paths(stdpath 'config', 'plugin', 'packer_compiled.lua'),
   plugin_package = 'packer',
@@ -111,7 +115,7 @@ end
 local snapshotted_plugins = {}
 a.describe('Packer testing ', function()
   local snapshot_name = 'test'
-  local test_path = join_paths(config.snapshot_path, snapshot_name)
+  local test_path = join_paths(config.snapshot.path, snapshot_name)
   local snapshot = require 'packer.snapshot'
   snapshot.cfg(config)
 
@@ -154,7 +158,7 @@ a.describe('Packer testing ', function()
 
   a.describe('packer.rollback()', function()
     local rollback_snapshot_name = 'rollback_test'
-    local rollback_test_path = join_paths(config.snapshot_path, rollback_snapshot_name)
+    local rollback_test_path = join_paths(config.snapshot.path, rollback_snapshot_name)
     local prev_commit_cmd = 'git rev-parse --short HEAD~5'
     local get_rev_cmd = 'git rev-parse --short HEAD'
 


### PR DESCRIPTION
These commits mainly aims to:

1. Improve the functionality of snapshots
2. Add more user autocmds
3. Echo informative messages when a `Packer*` command is finished

For the first point, now packer are capable to:
- automatically generate snapshot files on sync/update/remote/install
- allow using functions to specify the name of snapshot files and snapshot path
- generate human-readable `.json` with each package in a seperate line and is always sorted in ascending order, so that it is easier to track with version control tools like git
- `PackerSnapshot` can take any number of arguments (`nargs=*`). When no argument is given, packer will automatically fall back to the default snapshot name
- add `.json` appendix for the default snapshot name
- use `config.snapshot.name`, `config.snapshot.path`, and `config.snapshot.auto`, and `config.snapshot.silent_overwrite` to configure snapshot behavior

![image](https://user-images.githubusercontent.com/76579810/211988120-136290bc-2251-4fb6-8a82-d3b1acfee771.png)
More human-redable

![image](https://user-images.githubusercontent.com/76579810/211991042-2f9df05d-6656-4d6c-b601-12ceb6403c5d.png)
Clearer version control

The the second point:
- new user autocmds `PackerInstallComplete`, `PackerUpdateComplete`, `PackerCleanComplete`, `PackerSnapshotComplete`, `PackerSnapshotRollbackComplete`, `PackerSnapshotDeleteComplete`, and `PackerCompileComplete` are added

For the third point:
- in the function `packer.on_complete` a notification is added to inform user of the completion of a task (i.e. sync, install, update, snapshot ...)

Some side notes: thank you for this awesome plugin, I've used it for over a year and love it. For me it is the fastest package manager since I can disable packer itself and only load the compiled file if it is there. Taking advantage of this feature packer is noticeably faster than lazy.nvim (15 ~ 25ms for packer and 25~35ms for lazy.nvim, though both is fast enough). Use packer as a 'compiler' also means that the startup time will not increase when the config file is broken into smaller files, as long as the specs are the same. Hoping packer keep thriving and keep fast in the future :)