### PR TITLE
README: add Lua example code for auto-running PackerCompile

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,16 @@ vim.cmd([[
 ]])
 ```
 
+or using the equivalent Lua code:
+```lua
+local augroup_packer = vim.api.nvim_create_augroup("packer_user_config", { clear = true })
+vim.api.nvim_create_autocmd({ "BufWritePost" }, {
+	pattern = "plugins.lua",
+	group = augroup_packer,
+	command = "source <afile> | PackerCompile",
+})
+```
+
 ## Bootstrapping
 
 If you want to automatically install and set up `packer.nvim` on any machine you clone your configuration to,


### PR DESCRIPTION
Many users come to Packer because they can migrate to a complete Lua-based config for NeoVim.

Thus it makes sense to have a code example not only in Vimscript for auto-running PackerCompile on changes to `plugins.lua` but also an example in Lua.

Reference: https://neovim.io/doc/user/lua-guide.html#lua-guide-autocommands-group
