### PR TITLE
Detect git ssh protocols

### DIFF
--- a/lua/packer/plugin_utils.lua
+++ b/lua/packer/plugin_utils.lua
@@ -24,6 +24,9 @@ plugin_utils.guess_type = function(plugin)
     plugin.type = plugin_utils.local_plugin_type
   elseif
     string.sub(plugin.path, 1, 6) == 'git://'
+    or string.sub(plugin.path, 1, 6) == 'ssh://'
+    or string.sub(plugin.path, 1, 10) == 'git+ssh://'
+    or string.sub(plugin.path, 1, 10) == 'ssh+git://'
     or string.sub(plugin.path, 1, 4) == 'http'
     or string.match(plugin.path, '@')
   then


### PR DESCRIPTION
packer.nvim errors when installing `use { 'ssh://git.company/repo' }`
 I've tried `git@git.company/repo`, `https://git.company/repo`, `git://git.company/repo` but one of these urls work with packer or with `git clone`.

ssh, git+ssh, ssh+git are all names for git's ssh protocol. I tested this locally and I'm able to install the package.

https://git.kernel.org/pub/scm/git/git.git/tree/connect.c?id=c05186cc38ca4605bff1f275619d7d0faeaf2fa5