### PR TITLE
Include branch in plugin information

### DIFF
--- a/lua/packer/compile.lua
+++ b/lua/packer/compile.lua
@@ -358,6 +358,7 @@ local function make_loaders(_, plugins, output_lua, should_profile)
 
       -- Add the git URL for displaying in PackerStatus and PackerSync. https://github.com/wbthomason/packer.nvim/issues/542
       loaders[name].url = plugin.url
+      loaders[name].branch = plugin.branch
 
       if plugin.ft then
         plugin.simple_load = false

--- a/lua/packer/display.lua
+++ b/lua/packer/display.lua
@@ -97,6 +97,7 @@ end
 local status_keys = {
   'path',
   'url',
+  'branch',
   'commands',
   'keys',
   'module',


### PR DESCRIPTION
This PR includes the branch information for a plugin to be displayed in `:PackerStatus`. This information is also very helpful for https://github.com/axieax/urlview.nvim/issues/50, to be able to navigate to repo URLs with the desired branch.