### PR TITLE
fix #1100: force Git fetch during updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,9 +301,9 @@ default configuration values (and structure of the configuration table) are:
   git = {
     cmd = 'git', -- The base command for git operations
     subcommands = { -- Format strings for git subcommands
-      update         = 'pull --ff-only --progress --rebase=false',
+      update         = 'pull --ff-only --progress --rebase=false --force',
       install        = 'clone --depth %i --no-single-branch --progress',
-      fetch          = 'fetch --depth 999999 --progress',
+      fetch          = 'fetch --depth 999999 --progress --force',
       checkout       = 'checkout %s --',
       update_branch  = 'merge --ff-only @{u}',
       current_branch = 'branch --show-current',

--- a/doc/packer.txt
+++ b/doc/packer.txt
@@ -215,9 +215,9 @@ default values: >lua
     git = {
       cmd = 'git', -- The base command for git operations
       subcommands = { -- Format strings for git subcommands
-        update         = 'pull --ff-only --progress --rebase=false',
+        update         = 'pull --ff-only --progress --rebase=false --force',
         install        = 'clone --depth %i --no-single-branch --progress',
-        fetch          = 'fetch --depth 999999 --progress',
+        fetch          = 'fetch --depth 999999 --progress --force',
         checkout       = 'checkout %s --',
         update_branch  = 'merge --ff-only @{u}',
         current_branch = 'branch --show-current',

--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -27,10 +27,10 @@ local config_defaults = {
     mark_breaking_changes = true,
     cmd = 'git',
     subcommands = {
-      update = 'pull --ff-only --progress --rebase=false',
+      update = 'pull --ff-only --progress --rebase=false --force',
       update_head = 'merge FETCH_HEAD',
       install = 'clone --depth %i --no-single-branch --progress',
-      fetch = 'fetch --depth 999999 --progress',
+      fetch = 'fetch --depth 999999 --progress --force',
       checkout = 'checkout %s --',
       update_branch = 'merge --ff-only @{u}',
       current_branch = 'rev-parse --abbrev-ref HEAD',


### PR DESCRIPTION
Fixes #1100. Ensures packer updates don't fail when upstream force-pushes tags. Reopening #1101, because I've tested the solution proposed here by @antoineco. I think it's the best way forward: https://github.com/wbthomason/packer.nvim/issues/1100#issuecomment-1657036413.