### PR TITLE
Clarify installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ Have a problem or idea? Make an [issue](https://github.com/wbthomason/packer.nvi
   symbolic links requires admin privileges on Windows - credit to @TimUntersberger for this note)
 
 ## Quickstart
-To get started, first clone this repository to somewhere on your `packpath`, e.g.:
+To get started, first clone this repository to somewhere on your `packpath`,
+under the directory path `pack/packer/start/`. For example:
 
 > Unix, Linux Installation
 

--- a/doc/packer.txt
+++ b/doc/packer.txt
@@ -49,9 +49,10 @@ FEATURES                                         *packer-intro-features*
 ==============================================================================
 QUICKSTART                                       *packer-intro-quickstart*
 
-To get started, first clone this repository to somewhere on your `packpath`, e.g.: >sh
+To get started, first clone this repository to somewhere on your `packpath`,
+under the directory path `pack/packer/start/`. For example: >sh
   git clone https://github.com/wbthomason/packer.nvim\
-   ~/.local/share/nvim/site/pack/packer/opt/packer.nvim
+   ~/.local/share/nvim/site/pack/packer/start/packer.nvim
 
 
 Then you can write your plugin specification in Lua, e.g. (in `~/.config/nvim/lua/plugins.lua`): >lua


### PR DESCRIPTION
The old instructions said that the Git repository needs to be cloned somewhere on your `packpath`. However, it actually needs to be installed in the `pack/FOOBAR/start/` subdirectory of a directory in `packpath`, replacing `FOOBAR` with any name. This fix will prevent confusion for users who are still learning `packpath` and who may have their configuration in `~/.config/nvim/` rather than `~/.local/share/nvim/site/` .

This commit also fixes the documentation in `doc/packer.txt` to match `README.md` . In particular, the mention of the `opt` directory was fixed, it now mentions the `start` directory.