### PR TITLE
Update luarocks.lua

### DIFF
--- a/lua/packer/luarocks.lua
+++ b/lua/packer/luarocks.lua
@@ -20,7 +20,7 @@ end
 
 local lua_version = nil
 if jit then
-  local jit_version = string.gsub(jit.version, 'LuaJIT ', '')
+  local jit_version = '2.1.0-beta3'
   lua_version = { lua = string.gsub(_VERSION, 'Lua ', ''), jit = jit_version, dir = jit_version }
 else
   return {


### PR DESCRIPTION
this (bandaid) pr resolves an issue where neovim > 0.8 depends on a more recent version of luajit which is not supported by packer currently.