### PR TITLE
Fix for vim deprecation warning: vim.tbl_islist changed to vim.islist

### DIFF
--- a/lua/packer.lua
+++ b/lua/packer.lua
@@ -170,7 +170,7 @@ packer.use_rocks = function(rock)
   if type(rock) == 'string' then
     rock = { rock }
   end
-  if not vim.tbl_islist(rock) and type(rock[1]) == 'string' then
+  if not vim.islist(rock) and type(rock[1]) == 'string' then
     rocks[rock[1]] = rock
   else
     for _, r in ipairs(rock) do
@@ -281,7 +281,7 @@ manage = function(plugin_data)
       type(plugin_spec.requires) == 'string'
       or (
         type(plugin_spec.requires) == 'table'
-        and not vim.tbl_islist(plugin_spec.requires)
+        and not vim.islist(plugin_spec.requires)
         and #plugin_spec.requires == 1
       )
     then


### PR DESCRIPTION
Reported issue #1278.

Simple fix from `vim.tbl_islist` to `vim.islist`, in two places, without any further changes.

Ensures stability when neovim updates to v0.12.